### PR TITLE
fix: Specify /chat redirect as `308` permanent redirect

### DIFF
--- a/src/pages/chat.astro
+++ b/src/pages/chat.astro
@@ -1,3 +1,6 @@
 ---
+// Server-render page to avoid temporary flash of "redirecting..." plain text page
+export const prerender = false;
+
 return Astro.redirect("https://discord.gg/8Vy2bbQ5C2", 308);
 ---


### PR DESCRIPTION
- Add redirect code `308` to `/chat`
- Server-side render the page to prevent redirection screen from flashing on production