### PR TITLE
Add `.editorconfig` and format all files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{*.md,*.mdx}]
+trim_trailing_whitespace = false

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,14 +1,14 @@
-import { defineConfig } from "astro/config";
 import cloudflare from "@astrojs/cloudflare";
-import sitemap from "@astrojs/sitemap";
-import react from "@astrojs/react";
 import markdoc from "@astrojs/markdoc";
-import autoprefixer from "autoprefixer";
-import postcssUtopia from "postcss-utopia";
-import postcssMediaMinMax from "postcss-media-minmax";
+import react from "@astrojs/react";
+import sitemap from "@astrojs/sitemap";
 import postcssLogicalViewportUnits from "@csstools/postcss-logical-viewport-units";
-import postcssClamp from "postcss-clamp";
+import { defineConfig } from "astro/config";
+import autoprefixer from "autoprefixer";
 import cssnano from "cssnano";
+import postcssClamp from "postcss-clamp";
+import postcssMediaMinMax from "postcss-media-minmax";
+import postcssUtopia from "postcss-utopia";
 
 // https://astro.build/config
 export default defineConfig({

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,25 +1,27 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
-	"files": {
-		"ignore": [
-			".astro",
-			"node_modules",
-			"playwright-report",
-			"test-results",
-			"dist",
-			".vscode"
-		]
-	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "space"
-	},
-	"organizeImports": { "enabled": true },
-	"linter": { "enabled": true, "rules": { "recommended": true } },
-	"overrides": [
-		{
-			"include": ["*.astro", "**/*.astro"],
-			"javascript": { "globals": ["exports"] }
-		}
-	]
+  "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
+  "files": {
+    "ignore": [
+      ".astro",
+      "node_modules",
+      "playwright-report",
+      "test-results",
+      "dist",
+      ".vscode",
+      // PostCSS
+      "src/styles/theme.css"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space"
+  },
+  "organizeImports": { "enabled": true },
+  "linter": { "enabled": true, "rules": { "recommended": true } },
+  "overrides": [
+    {
+      "include": ["*.astro", "**/*.astro"],
+      "javascript": { "globals": ["exports"] }
+    }
+  ]
 }

--- a/keystatic.config.tsx
+++ b/keystatic.config.tsx
@@ -1,4 +1,4 @@
-import { config, fields, collection } from "@keystatic/core";
+import { collection, config, fields } from "@keystatic/core";
 
 export default config({
   storage: {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,7 +1,7 @@
 ---
+import { RiDiscordFill } from "react-icons/ri";
 import siteInfo from "~/data/site-info";
 import Logo from "./Logo.astro";
-import { RiDiscordFill } from "react-icons/ri";
 
 const { socialLinks } = siteInfo;
 ---

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,5 @@
+import { defineCollection, reference, z } from "astro:content";
 import { glob } from "astro/loaders";
-import { z, defineCollection, reference } from "astro:content";
 import type { RoughAnnotationType } from "rough-notation/lib/model";
 import type { NamesakeColor } from "~/data/colors";
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,6 @@
 ---
-import { AstroFont } from "astro-font";
 import { join } from "node:path";
+import { AstroFont } from "astro-font";
 import Footer from "~/components/Footer.astro";
 import Header from "~/components/Header.astro";
 import type { NamesakeColor } from "~/data/colors";

--- a/src/pages/[id].astro
+++ b/src/pages/[id].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection, type CollectionEntry, render } from "astro:content";
+import { type CollectionEntry, getCollection, render } from "astro:content";
 import ProseLayout from "~/layouts/ProseLayout.astro";
 
 export interface Props {

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -1,12 +1,12 @@
 ---
 import { Image } from "astro:assets";
-import ProseLayout from "~/layouts/ProseLayout.astro";
 import {
+  type CollectionEntry,
   getCollection,
   getEntries,
-  type CollectionEntry,
   render,
 } from "astro:content";
+import ProseLayout from "~/layouts/ProseLayout.astro";
 
 export interface Props {
   post: CollectionEntry<"posts">;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,8 +1,8 @@
 ---
-import BaseLayout from "~/layouts/BaseLayout.astro";
 import { getCollection, getEntries } from "astro:content";
 import ArticleLink from "~/components/ArticleLink.astro";
 import PageHeader from "~/components/PageHeader.astro";
+import BaseLayout from "~/layouts/BaseLayout.astro";
 
 const posts = await getCollection("posts");
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import { Image } from "astro:assets";
-import heroIllustration from "~/content/pages/_images/hero-form.png";
 import Partners from "~/components/Partners.astro";
+import heroIllustration from "~/content/pages/_images/hero-form.png";
 import siteInfo from "~/data/site-info";
 import BaseLayout from "~/layouts/BaseLayout.astro";
 

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -1,5 +1,5 @@
 import AxeBuilder from "@axe-core/playwright";
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 const paths = [
   "/",

--- a/tests/chat.spec.ts
+++ b/tests/chat.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.describe("chat", () => {
   test("should redirect to Discord invite", async ({ page }) => {


### PR DESCRIPTION
Add an `.editorconfig` file and format all files using `pnpm biome --fix`.

Add `theme.css` to Biome ignored file to suppress warnings about PostCSS.

Resolves #179 