### PR TITLE
feat: Improve accessibility of navigation list

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,14 +3,22 @@ import siteInfo from "~/data/site-info";
 import Logo from "./Logo.astro";
 
 const { urls } = siteInfo;
+const { pathname } = Astro.url;
 ---
 
 <header>
-  <a href="/" aria-label="Namesake homepage" id="logo"><Logo /></a>
-  <nav>
-    <a href="/blog" class="button ghost small">Blog</a>
-    <a href="/donate" class="button secondary small">Donate</a>
-    <a href={urls.app} class="button primary small">Sign In</a>
+  <a href="/" aria-label="Home" id="logo"><Logo /></a>
+  <nav aria-label="Site">
+    <ul role="list">
+      <li>
+        <a
+          href="/blog"
+          aria-current={pathname.slice(1) === "blog" ? "page" : "false"}
+          class="button ghost small">Blog</a>
+      </li>
+      <li><a href="/donate" class="button secondary small">Donate</a></li>
+      <li><a href={urls.app} class="button primary small">Sign In</a></li>
+    </ul>
   </nav>
 </header>
 
@@ -28,22 +36,23 @@ const { urls } = siteInfo;
     top: 0;
     display: flex;
     align-items: center;
-    justify-content: flex-start;
-    padding: var(--space-l);
+    justify-content: space-between;
+    padding: var(--space-m) var(--space-l);
     width: 100%;
     max-width: 1200px;
     margin-inline: auto;
   }
 
-  a {
-    padding: var(--space-xs) var(--space-s);
-    margin: calc(var(--space-xs) * -1);
-    border-radius: 5px;
-  }
-
-  nav {
+  ul {
+    list-style: none;
     display: flex;
-    gap: var(--space-l);
-    margin-inline-start: auto;
+    padding: unset;
+    margin: unset;
+    gap: var(--space-xs);
+
+    a {
+      padding: var(--space-xs) var(--space-s);
+      border-radius: 5px;
+    }
   }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -13,11 +13,12 @@ const { pathname } = Astro.url;
       <li>
         <a
           href="/blog"
-          aria-current={pathname.slice(1) === "blog" ? "page" : "false"}
-          class="button ghost small">Blog</a>
+          aria-current={pathname.slice(1).startsWith("blog") ? "page" : "false"}
+          >Blog</a
+        >
       </li>
-      <li><a href="/donate" class="button secondary small">Donate</a></li>
-      <li><a href={urls.app} class="button primary small">Sign In</a></li>
+      <li><a href="/donate">Donate</a></li>
+      <li><a href={urls.app}>Sign In</a></li>
     </ul>
   </nav>
 </header>
@@ -35,9 +36,9 @@ const { pathname } = Astro.url;
   header {
     top: 0;
     display: flex;
-    align-items: center;
+    align-items: baseline;
     justify-content: space-between;
-    padding: var(--space-m) var(--space-l);
+    padding: var(--space-l);
     width: 100%;
     max-width: 1200px;
     margin-inline: auto;
@@ -48,11 +49,20 @@ const { pathname } = Astro.url;
     display: flex;
     padding: unset;
     margin: unset;
-    gap: var(--space-xs);
 
     a {
       padding: var(--space-xs) var(--space-s);
       border-radius: 5px;
+      text-decoration: none;
+      font-size: var(--step-0);
+      font-weight: 600;
+
+      &[aria-current="page"],
+      &:hover {
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 1.5px;
+      }
     }
   }
 </style>


### PR DESCRIPTION
Improve the accessibility of the navigation list:

1. Add an `aria-label` to `nav` so that it is announced as "Site navigation" rather than just "navigation" (for which there are other `nav` elements on the site)
2. Wrap nav links within an unordered list, so that screen reader users will hear the number of nav items that are present
3. Explicitly set `ul role="list"` to prevent older versions of Safari from ignoring the `list` role (this is a bug with to how old versions of Safari handle `list-style: none` on `ul` elements)
4. Set `aria-current="page"` for the "Blog" link when that page (or any subpage) is active
5. Tweak visual styles and underline current page