### PR TITLE
fix: Remove trailing slashes from URLs in Cloudflare

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,6 +23,11 @@ export default defineConfig({
   integrations: [sitemap(), embeds(), mdx(), react(), markdoc(), keystatic()],
   prefetch: true,
   trailingSlash: "never",
+  build: {
+    // Eliminate trailing slashes from Cloudflare Pages
+    // https://creativehike.com/posts/removing-trailng-slashes-astro
+    format: "file",
+  },
   vite: {
     ssr: {
       external: ["buffer", "path", "fs", "os", "crypto", "async_hooks"].map(


### PR DESCRIPTION
Update Astro config to output `file` instead of `directory` (default).

https://creativehike.com/posts/removing-trailng-slashes-astro

Fixes #86 