### PR TITLE
content: Add Bluesky social link to footer

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
   "files": {
     "includes": [
       "**",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@axe-core/playwright": "^4.10.2",
     "@keystatic/astro": "^5.0.6",
     "@keystatic/core": "^0.5.48",
+    "@remixicon/react": "^4.6.0",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
     "astro": "^5.13.5",
@@ -42,7 +43,6 @@
     "markdown-it": "^14.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-icons": "^5.5.0",
     "rough-notation": "^0.5.1",
     "sanitize-html": "^2.17.0",
     "typescript": "^5.9.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@keystatic/core':
         specifier: ^0.5.48
         version: 0.5.48(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@remixicon/react':
+        specifier: ^4.6.0
+        version: 4.6.0(react@19.1.1)
       '@types/react':
         specifier: ^19.1.12
         version: 19.1.12
@@ -77,9 +80,6 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
-      react-icons:
-        specifier: ^5.5.0
-        version: 5.5.0(react@19.1.1)
       rough-notation:
         specifier: ^0.5.1
         version: 0.5.1
@@ -1855,6 +1855,11 @@ packages:
     resolution: {integrity: sha512-OR/pwZReWbCIxuHJYB1L4fTwliA+mzVvUJMWwXIRy6Eh5d07spS3FZEKFvOgjMxA1nyv5PLf8eyr5RuuP1GGAA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@remixicon/react@4.6.0':
+    resolution: {integrity: sha512-bY56maEgT5IYUSRotqy9h03IAKJC85vlKtWFg2FKzfs8JPrkdBAYSa9dxoUSKFwGzup8Ux6vjShs9Aec3jvr2w==}
+    peerDependencies:
+      react: '>=18.2.0'
 
   '@rolldown/pluginutils@1.0.0-beta.9':
     resolution: {integrity: sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==}
@@ -3791,11 +3796,6 @@ packages:
     resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
     peerDependencies:
       react: ^19.1.1
-
-  react-icons@5.5.0:
-    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
-    peerDependencies:
-      react: '*'
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -6934,6 +6934,10 @@ snapshots:
       '@react-types/shared': 3.31.0(react@19.1.1)
       react: 19.1.1
 
+  '@remixicon/react@4.6.0(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+
   '@rolldown/pluginutils@1.0.0-beta.9': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.50.1)':
@@ -9332,10 +9336,6 @@ snapshots:
     dependencies:
       react: 19.1.1
       scheduler: 0.26.0
-
-  react-icons@5.5.0(react@19.1.1):
-    dependencies:
-      react: 19.1.1
 
   react-refresh@0.17.0: {}
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,5 @@
 ---
-import { RiHeart3Line } from "react-icons/ri";
+import { RiHeart3Line } from "@remixicon/react";
 import siteInfo from "~/data/site-info";
 import Subscribe from "./Subscribe.astro";
 

--- a/src/components/Subscribe.astro
+++ b/src/components/Subscribe.astro
@@ -1,5 +1,5 @@
 ---
-import { RiArrowRightLine } from "react-icons/ri";
+import { RiArrowRightLine } from "@remixicon/react";
 ---
 
 <form

--- a/src/data/site-info.ts
+++ b/src/data/site-info.ts
@@ -1,26 +1,28 @@
-import type { IconType } from "react-icons/lib";
 import {
+  type RemixiconComponentType,
+  RiBlueskyFill,
   RiDiscordFill,
   RiGithubFill,
   RiInstagramFill,
   RiLinkedinBoxFill,
   RiMailSendFill,
   RiRssFill,
-} from "react-icons/ri";
+} from "@remixicon/react";
 
 type SocialPlatform =
-  | "rss"
+  | "bluesky"
   | "discord"
+  | "email"
   | "github"
   | "instagram"
   | "linkedin"
-  | "email";
+  | "rss";
 
 export type SocialLink = {
   name: string;
   text: string;
   href: string;
-  Icon: IconType;
+  Icon: RemixiconComponentType;
 };
 
 export type SiteInfo = {
@@ -75,6 +77,12 @@ const siteInfo: SiteInfo = {
       text: "Follow Namesake on Instagram",
       href: "https://www.instagram.com/namesake.fyi",
       Icon: RiInstagramFill,
+    },
+    bluesky: {
+      name: "Bluesky",
+      text: "Follow Namesake on Bluesky",
+      href: "https://bsky.app/profile/namesake.fyi",
+      Icon: RiBlueskyFill,
     },
     linkedin: {
       name: "LinkedIn",

--- a/src/pages/brand-assets/_components/BrandAssetCard.astro
+++ b/src/pages/brand-assets/_components/BrandAssetCard.astro
@@ -1,5 +1,5 @@
 ---
-import { RiDownloadLine } from "react-icons/ri";
+import { RiDownloadLine } from "@remixicon/react";
 
 export type Props = {
   name: string;

--- a/src/pages/brand-assets/index.astro
+++ b/src/pages/brand-assets/index.astro
@@ -1,5 +1,5 @@
 ---
-import { RiDownloadLine } from "react-icons/ri";
+import { RiDownloadLine } from "@remixicon/react";
 import PageHeader from "~/components/PageHeader.astro";
 import BaseLayout from "~/layouts/BaseLayout.astro";
 import BrandAssetCard from "./_components/BrandAssetCard.astro";

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import { Image } from "astro:assets";
 import { getEntry, render } from "astro:content";
-import { RiArrowRightLine } from "react-icons/ri";
+import { RiArrowRightLine } from "@remixicon/react";
 import Partners from "~/components/Partners.astro";
 import heroIllustration from "~/content/pages/_images/hero-form.png";
 import siteInfo from "~/data/site-info";


### PR DESCRIPTION
Add Bluesky link in site footer.

<img width="712" height="169" alt="CleanShot 2025-09-14 at 21 33 18@2x" src="https://github.com/user-attachments/assets/377a1859-4a81-4a71-bc70-96b34e7f1c51" />

Additionally, replace `react-icons` dependency, which did not include the latest Remix Icons, with `@remixicon/react`, their own first-party package, which includes the latest icons (like Bluesky).