### PR TITLE
fix: Do not run Sanity deploy on dependabot updates

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -12,6 +12,7 @@ jobs:
     name: Deploy Sanity Studio
     runs-on: ubuntu-latest
     permissions: write-all
+    if: ${{ github.actor != 'dependabot[bot]' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Skip the Sanity workflow when the PR is created by dependabot.