### PR TITLE
Add prompt to clear data after download

### DIFF
--- a/src/components/react/common/Modal/Modal.css
+++ b/src/components/react/common/Modal/Modal.css
@@ -31,7 +31,7 @@
   border: 2px solid var(--border-color);
   outline: none;
   width: max-content;
-  max-width: 300px;
+  max-width: 480px;
 
   &[data-entering] {
     animation: modal-zoom 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275);

--- a/src/components/react/forms/DeleteFormDataModal/DeleteFormDataModal.css
+++ b/src/components/react/forms/DeleteFormDataModal/DeleteFormDataModal.css
@@ -1,0 +1,20 @@
+.delete-form-data-modal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-m);
+}
+
+.delete-form-data-modal-description {
+  margin: 0;
+  font-size: var(--step-0);
+  line-height: var(--line-height-body);
+  color: var(--text-color-secondary);
+}
+
+.delete-form-data-modal-actions {
+  display: flex;
+  gap: var(--space-s);
+  justify-content: flex-end;
+  margin-top: var(--space-s);
+}
+

--- a/src/components/react/forms/DeleteFormDataModal/DeleteFormDataModal.css
+++ b/src/components/react/forms/DeleteFormDataModal/DeleteFormDataModal.css
@@ -17,4 +17,3 @@
   justify-content: flex-end;
   margin-top: var(--space-s);
 }
-

--- a/src/components/react/forms/DeleteFormDataModal/DeleteFormDataModal.test.tsx
+++ b/src/components/react/forms/DeleteFormDataModal/DeleteFormDataModal.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { DeleteFormDataModal } from "./DeleteFormDataModal";
+
+// Mock the database module
+vi.mock("@/db/database", () => ({
+  clearAllFields: vi.fn().mockResolvedValue(undefined),
+  getAllFields: vi.fn().mockResolvedValue([
+    { field: "firstName", value: "John" },
+    { field: "lastName", value: "Doe" },
+  ]),
+}));
+
+describe("DeleteFormDataModal", () => {
+  it("shows response count when data exists", async () => {
+    render(<DeleteFormDataModal />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 responses/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows delete button when data exists", async () => {
+    render(<DeleteFormDataModal />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /delete stored data/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows no data message when no responses exist", async () => {
+    const { getAllFields } = await import("@/db/database");
+    vi.mocked(getAllFields).mockResolvedValueOnce([]);
+
+    render(<DeleteFormDataModal />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no form responses/i)).toBeInTheDocument();
+    });
+  });
+
+  it("hides delete button when no data exists", async () => {
+    const { getAllFields } = await import("@/db/database");
+    vi.mocked(getAllFields).mockResolvedValueOnce([]);
+
+    render(<DeleteFormDataModal />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /delete data/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("opens modal when delete button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DeleteFormDataModal />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /delete stored data/i }),
+      ).toBeInTheDocument();
+    });
+
+    const triggerButton = screen.getByRole("button", {
+      name: /delete stored data/i,
+    });
+    await user.click(triggerButton);
+
+    expect(
+      screen.getByRole("heading", { name: /delete stored data/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows response count in modal confirmation", async () => {
+    const user = userEvent.setup();
+    render(<DeleteFormDataModal />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /delete stored data/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /delete stored data/i }),
+    );
+
+    expect(screen.getByText(/permanently delete all/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 form responses/i)).toBeInTheDocument();
+  });
+
+  it("closes modal when cancel is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DeleteFormDataModal />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /delete stored data/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /delete stored data/i }),
+    );
+
+    const cancelButton = screen.getByRole("button", { name: /cancel/i });
+    await user.click(cancelButton);
+
+    expect(
+      screen.queryByRole("heading", { name: /delete stored data/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls clearAllFields when delete is clicked", async () => {
+    const user = userEvent.setup();
+    const { clearAllFields } = await import("@/db/database");
+
+    render(<DeleteFormDataModal />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /delete stored data/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /delete stored data/i }),
+    );
+
+    const deleteButton = screen.getByRole("button", {
+      name: /delete all data/i,
+    });
+    await user.click(deleteButton);
+
+    expect(clearAllFields).toHaveBeenCalled();
+  });
+});

--- a/src/components/react/forms/DeleteFormDataModal/DeleteFormDataModal.tsx
+++ b/src/components/react/forms/DeleteFormDataModal/DeleteFormDataModal.tsx
@@ -1,10 +1,10 @@
 import { RiDeleteBin2Line } from "@remixicon/react";
 import { useEffect, useState } from "react";
+import { clearAllFields, getAllFields } from "@/db/database";
 import { Button } from "../../common/Button";
 import { Heading } from "../../common/Content";
 import { Dialog, DialogTrigger } from "../../common/Dialog";
 import { Modal } from "../../common/Modal";
-import { clearAllFields, getAllFields } from "@/db/database";
 import "./DeleteFormDataModal.css";
 import { UAParser } from "ua-parser-js";
 import { Banner } from "../../common/Banner";

--- a/src/components/react/forms/DeleteFormDataModal/DeleteFormDataModal.tsx
+++ b/src/components/react/forms/DeleteFormDataModal/DeleteFormDataModal.tsx
@@ -1,0 +1,111 @@
+import { RiDeleteBin2Line } from "@remixicon/react";
+import { useEffect, useState } from "react";
+import { Button } from "../../common/Button";
+import { Heading } from "../../common/Content";
+import { Dialog, DialogTrigger } from "../../common/Dialog";
+import { Modal } from "../../common/Modal";
+import { clearAllFields, getAllFields } from "@/db/database";
+import "./DeleteFormDataModal.css";
+import { UAParser } from "ua-parser-js";
+import { Banner } from "../../common/Banner";
+
+export function DeleteFormDataModal() {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [responseCount, setResponseCount] = useState<number | null>(null);
+
+  const { device } = UAParser(navigator.userAgent);
+
+  useEffect(() => {
+    const fetchCount = async () => {
+      try {
+        const fields = await getAllFields();
+        setResponseCount(fields.length);
+      } catch (error) {
+        console.error("Failed to fetch response count:", error);
+        setResponseCount(0);
+      }
+    };
+
+    fetchCount();
+  }, []);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await clearAllFields();
+      setIsOpen(false);
+      setResponseCount(0);
+    } catch (error) {
+      setErrorMessage(`Failed to delete form data. Error: ${error}`);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const hasData = responseCount !== null && responseCount > 0;
+
+  return (
+    <>
+      {responseCount === null ? (
+        <p>Loading...</p>
+      ) : hasData ? (
+        <p>
+          There are{" "}
+          <strong>{`${responseCount} response${responseCount !== 1 ? "s" : ""}`}</strong>{" "}
+          stored on this browser. Anyone else who visits Namesake on{" "}
+          <strong>{`this ${device.model ?? "device"}`}</strong> will be able to
+          see your form responses.
+        </p>
+      ) : (
+        <p>
+          There are <strong>no form responses</strong> stored on this browser.
+          If you are using a public computer, remember to clean up any
+          downloaded files when you are done!
+        </p>
+      )}
+      {hasData && (
+        <DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
+          <Button variant="secondary" icon={RiDeleteBin2Line}>
+            Delete stored data
+          </Button>
+          <Modal isDismissable>
+            <Dialog>
+              <div className="delete-form-data-modal">
+                <Heading slot="title">Delete stored data?</Heading>
+                <p className="delete-form-data-modal-description">
+                  This will permanently delete all{" "}
+                  <strong>
+                    {`${responseCount} form ${responseCount !== 1 ? "responses" : "response"}`}
+                  </strong>{" "}
+                  from this browser. You cannot undo this action.
+                </p>
+                {errorMessage && (
+                  <Banner variant="error">{errorMessage}</Banner>
+                )}
+                <div className="delete-form-data-modal-actions">
+                  <Button
+                    slot="close"
+                    variant="secondary"
+                    isDisabled={isDeleting}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="primary"
+                    icon={RiDeleteBin2Line}
+                    onPress={handleDelete}
+                    isPending={isDeleting}
+                  >
+                    {isDeleting ? "Deleting..." : "Delete all data"}
+                  </Button>
+                </div>
+              </div>
+            </Dialog>
+          </Modal>
+        </DialogTrigger>
+      )}
+    </>
+  );
+}

--- a/src/components/react/forms/DeleteFormDataModal/index.ts
+++ b/src/components/react/forms/DeleteFormDataModal/index.ts
@@ -1,2 +1,1 @@
 export { DeleteFormDataModal } from "./DeleteFormDataModal";
-

--- a/src/components/react/forms/DeleteFormDataModal/index.ts
+++ b/src/components/react/forms/DeleteFormDataModal/index.ts
@@ -1,0 +1,2 @@
+export { DeleteFormDataModal } from "./DeleteFormDataModal";
+

--- a/src/pages/forms/done.astro
+++ b/src/pages/forms/done.astro
@@ -4,7 +4,7 @@ import ProseLayout from "@/layouts/ProseLayout.astro";
 ---
 
 <ProseLayout
-  title="Downloaded!"
+  title="Check your downloads"
   description="Your name change packet has downloaded. Review, print, and follow steps for filing."
   color="green"
   annotation="underline"

--- a/src/pages/forms/done.astro
+++ b/src/pages/forms/done.astro
@@ -1,13 +1,18 @@
 ---
+import { DeleteFormDataModal } from "@/components/react/forms/DeleteFormDataModal";
 import ProseLayout from "@/layouts/ProseLayout.astro";
 ---
 
 <ProseLayout
-  title="Form downloaded!"
+  title="It's done!"
   description="Your name change packet has downloaded. Review, print, and follow steps for filing."
   color="green"
   annotation="underline"
 >
-  Questions about filing? <a href="https://namesake.fyi/chat">Chat on Discord</a
-  > or <a href="mailto:hey@namesake.fyi">email us</a> for help.
+  <p>
+    Questions about filing? <a href="https://namesake.fyi/chat"
+      >Chat on Discord</a
+    > or <a href="mailto:hey@namesake.fyi">email us</a> for help.
+  </p>
+  <DeleteFormDataModal client:only="react" />
 </ProseLayout>

--- a/src/pages/forms/done.astro
+++ b/src/pages/forms/done.astro
@@ -4,7 +4,7 @@ import ProseLayout from "@/layouts/ProseLayout.astro";
 ---
 
 <ProseLayout
-  title="It's done!"
+  title="Downloaded!"
   description="Your name change packet has downloaded. Review, print, and follow steps for filing."
   color="green"
   annotation="underline"


### PR DESCRIPTION
- Add a modal on `/done` which allows clearing all browser data
- Show number of fields saved
- Add a warning about public computer use to remind people to clean up PDFs
- Update language on "done" page