### PR TITLE
Mobile fixes for form index layout

### DIFF
--- a/src/pages/forms/index.astro
+++ b/src/pages/forms/index.astro
@@ -77,15 +77,13 @@ const formsWithPdfs = await Promise.all(
 <style>
   .forms {
     display: grid;
-    gap: var(--space-l);
+    gap: var(--space-m);
     padding-block-end: var(--space-2xl);
-
-    @media (width > 400px) {
-      grid-template-columns: 1fr 1fr;
-    }
+    grid-template-columns: 1fr 1fr;
 
     @media (width > 600px) {
       grid-template-columns: 1fr 1fr 1fr;
+      gap: var(--space-l);
     }
 
     @media (width > 1000px) {
@@ -100,15 +98,27 @@ const formsWithPdfs = await Promise.all(
     flex-direction: column;
     justify-content: space-between;
     aspect-ratio: 8.5 / 11;
+    overflow: hidden;
     box-shadow:
       5px 5px 0 -3px var(--background-color),
       5px 5px 0 -2px var(--border-color),
       10px 10px 0 -5px var(--background-color),
       10px 10px 0 -4px var(--border-color);
 
+    @media (width < 600px) {
+      padding: var(--space-m) var(--space-m);
+      box-shadow:
+        5px 5px 0 -3px var(--background-color),
+        5px 5px 0 -2px var(--border-color);
+    }
+
     h3 {
       font-size: var(--step-1);
       line-height: var(--line-height-display);
+
+      @media (width < 600px) {
+        font-size: var(--step-0);
+      }
 
       a {
         text-decoration: none;


### PR DESCRIPTION
Keep two columns even on mobile in order for 8.5/11 aspect ratio not to consume entire screen