### PR TITLE
Content and usability fixes from Luke

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "sanity": "^4.19.0",
     "styled-components": "^6.1.19",
     "topojson-client": "^3.1.0",
-    "typed-usa-states": "^2.1.0",
     "typescript": "^5.9.3",
     "ua-parser-js": "^2.0.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,9 +140,6 @@ importers:
       topojson-client:
         specifier: ^3.1.0
         version: 3.1.0
-      typed-usa-states:
-        specifier: ^2.1.0
-        version: 2.1.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -8118,9 +8115,6 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
-
-  typed-usa-states@2.1.0:
-    resolution: {integrity: sha512-9HyajobhSjkrF/vg0f70AVBZUY7t9RqFowyyFtim2HmKQ+LtYh14AmIe+3dTfOH5zYrgSLgOlSR+luH9F0g6dw==}
 
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
@@ -18744,8 +18738,6 @@ snapshots:
   type-fest@0.8.1: {}
 
   type-fest@4.41.0: {}
-
-  typed-usa-states@2.1.0: {}
 
   typedarray-to-buffer@3.1.5:
     dependencies:

--- a/src/components/react/common/Modal/Modal.css
+++ b/src/components/react/common/Modal/Modal.css
@@ -31,7 +31,7 @@
   border: 2px solid var(--border-color);
   outline: none;
   width: max-content;
-  max-width: 480px;
+  max-width: min(480px, 95vw);
 
   &[data-entering] {
     animation: modal-zoom 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275);

--- a/src/components/react/forms/AddressField/AddressField.test.tsx
+++ b/src/components/react/forms/AddressField/AddressField.test.tsx
@@ -120,75 +120,11 @@ describe("AddressField", () => {
     expect(screen.queryByLabelText("County")).not.toBeInTheDocument();
   });
 
-  it("shows county selection when includeCounty is true and state is selected", async () => {
+  it("shows county selection when includeCounty is true", () => {
     renderWithFormProvider(<AddressField type="residence" includeCounty />);
 
-    // Initially county should not be visible
-    expect(screen.queryByLabelText("County")).not.toBeInTheDocument();
-
-    // Select California
-    const stateSelect = screen.getByRole("combobox", {
-      name: "State",
-    });
-    await userEvent.click(stateSelect);
-    const californiaOption = screen.getByRole("option", {
-      name: JURISDICTIONS.CA,
-    });
-    await userEvent.click(californiaOption);
-
-    // County dropdown should now be visible
-    const countySelect = screen.getByRole("combobox", {
-      name: "County",
-    });
-    expect(countySelect).toBeInTheDocument();
-
-    // Should be able to select a county
-    await userEvent.click(countySelect);
-    const losAngelesOption = screen.getByRole("option", {
-      name: "Los Angeles County",
-    });
-    await userEvent.click(losAngelesOption);
-    expect(countySelect).toHaveValue("Los Angeles County");
-  });
-
-  it("clears county selection when state changes", async () => {
-    renderWithFormProvider(<AddressField type="residence" includeCounty />);
-
-    // Select New York
-    const stateSelect = screen.getByRole("combobox", {
-      name: "State",
-    });
-    await userEvent.click(stateSelect);
-    const newYorkOption = screen.getByRole("option", {
-      name: JURISDICTIONS.NY,
-    });
-    await userEvent.click(newYorkOption);
-
-    // Select New York county
-    const countySelect = screen.getByRole("combobox", {
-      name: "County",
-    });
-    await userEvent.click(countySelect);
-    const queensCountyOption = screen.getByRole("option", {
-      name: "Queens County",
-    });
-    await userEvent.click(queensCountyOption);
-
-    // Change state to Massachusetts
-    await userEvent.click(stateSelect);
-    const massachusettsOption = screen.getByRole("option", {
-      name: JURISDICTIONS.MA,
-    });
-    await userEvent.click(massachusettsOption);
-
-    // County should update to Massachusetts counties
-    await userEvent.click(countySelect);
-    expect(
-      screen.queryByRole("option", { name: "Queens County" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("option", { name: "Suffolk County" }),
-    ).toBeInTheDocument();
+    const countyInput = screen.getByLabelText("County");
+    expect(countyInput).toBeInTheDocument();
   });
 
   it("renders the correct name for county field based on address type", async () => {
@@ -204,9 +140,7 @@ describe("AddressField", () => {
     });
     await userEvent.click(newYorkOption);
 
-    const countySelect = screen.getByRole("combobox", {
-      name: "County",
-    });
-    expect(countySelect).toHaveAttribute("name", "residenceCounty");
+    const countyInput = screen.getByLabelText("County");
+    expect(countyInput).toHaveAttribute("name", "residenceCounty");
   });
 });

--- a/src/components/react/forms/AddressField/AddressField.tsx
+++ b/src/components/react/forms/AddressField/AddressField.tsx
@@ -1,5 +1,4 @@
 import { type MaskitoOptions, maskitoTransform } from "@maskito/core";
-import { useEffect, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { ComboBox, ComboBoxItem } from "@/components/react/common/ComboBox";
 import { TextField } from "@/components/react/common/TextField";
@@ -20,11 +19,7 @@ export function AddressField({
   type,
   includeCounty = false,
 }: AddressFieldProps) {
-  const { control, watch } = useFormContext();
-  const [usaStatesWithCounties, setUsaStatesWithCounties] = useState<
-    typeof import("typed-usa-states/dist/states-with-counties") | null
-  >(null);
-  const [counties, setCounties] = useState<string[]>([]);
+  const { control } = useFormContext();
 
   const names: Record<
     AddressType,
@@ -51,36 +46,6 @@ export function AddressField({
       county: "mailingCounty",
     },
   };
-
-  const selectedState = watch(names[type].state);
-
-  useEffect(() => {
-    if (includeCounty) {
-      import("typed-usa-states/dist/states-with-counties")
-        .then((module) => {
-          setUsaStatesWithCounties(module);
-        })
-        .catch(() => {
-          setUsaStatesWithCounties(null);
-        });
-    }
-  });
-
-  useEffect(() => {
-    if (!includeCounty || !selectedState) {
-      setCounties([]);
-      return;
-    }
-
-    if (usaStatesWithCounties) {
-      const state = usaStatesWithCounties.usaStatesWithCounties.find(
-        (state) => state.abbreviation === selectedState,
-      );
-      if (state) {
-        setCounties(state.counties ?? []);
-      }
-    }
-  }, [includeCounty, selectedState, usaStatesWithCounties]);
 
   // Input mask: enforce ZIP code format of 12345-1234
   const maskitoOptions: MaskitoOptions = {
@@ -148,30 +113,18 @@ export function AddressField({
           </ComboBox>
         )}
       />
-      {includeCounty && counties.length > 0 && (
+      {includeCounty && (
         <Controller
           control={control}
           name={names[type].county}
           defaultValue=""
           render={({ field, fieldState: { invalid, error } }) => (
-            <ComboBox
+            <TextField
               {...field}
               label="County"
-              placeholder="Select county"
-              selectedKey={field.value}
-              onSelectionChange={(key) => {
-                field.onChange(key);
-              }}
               isInvalid={invalid}
               errorMessage={error?.message}
-              menuTrigger="focus"
-            >
-              {counties.map((county) => (
-                <ComboBoxItem key={county} id={county}>
-                  {county}
-                </ComboBoxItem>
-              ))}
-            </ComboBox>
+            />
           )}
         />
       )}

--- a/src/components/react/forms/Costs/Costs.css
+++ b/src/components/react/forms/Costs/Costs.css
@@ -1,0 +1,37 @@
+.namesake-costs {
+  border: 1px solid var(--border-color);
+  border-spacing: 0;
+  width: 100%;
+  max-width: 400px;
+  margin-block: var(--space-l);
+  table-layout: fixed;
+
+  th,
+  td {
+    padding: var(--space-2xs) var(--space-l);
+    width: 100px;
+  }
+
+  tbody tr:not(:last-child) td {
+    border-bottom: 1px dotted var(--text-color);
+  }
+
+  tfoot td {
+    font-size: var(--step-1);
+    padding-block: var(--space-s);
+    border-top: 1px solid var(--text-color);
+    font-weight: var(--weight-bold);
+  }
+
+  th:first-child,
+  td:first-child {
+    text-align: left;
+    padding-inline-end: var(--space-l);
+  }
+
+  th:last-child,
+  td:last-child {
+    text-align: right;
+  }
+}
+

--- a/src/components/react/forms/Costs/Costs.css
+++ b/src/components/react/forms/Costs/Costs.css
@@ -34,4 +34,3 @@
     text-align: right;
   }
 }
-

--- a/src/components/react/forms/Costs/Costs.tsx
+++ b/src/components/react/forms/Costs/Costs.tsx
@@ -1,0 +1,44 @@
+import { formatCurrency } from "@/utils/formatCurrency";
+import { formatTotalCosts, type Cost } from "@/utils/formatTotalCosts";
+import "./Costs.css";
+
+interface CostsProps {
+  costs: Cost[];
+}
+
+export function Costs({ costs }: CostsProps) {
+  if (!costs || costs.length === 0) {
+    return null;
+  }
+
+  const totalCosts = formatTotalCosts(costs);
+
+  return (
+    <table className="namesake-costs">
+      <thead className="visually-hidden">
+        <tr>
+          <th>Cost</th>
+          <th>Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        {costs.map((cost) => (
+          <tr key={cost.title}>
+            <td>
+              {cost.title}
+              {cost.required === "notRequired" && " (optional)"}
+            </td>
+            <td>{formatCurrency(cost.amount)}</td>
+          </tr>
+        ))}
+      </tbody>
+      <tfoot>
+        <tr>
+          <td>Total</td>
+          <td>{totalCosts}</td>
+        </tr>
+      </tfoot>
+    </table>
+  );
+}
+

--- a/src/components/react/forms/Costs/Costs.tsx
+++ b/src/components/react/forms/Costs/Costs.tsx
@@ -1,5 +1,5 @@
 import { formatCurrency } from "@/utils/formatCurrency";
-import { formatTotalCosts, type Cost } from "@/utils/formatTotalCosts";
+import { type Cost, formatTotalCosts } from "@/utils/formatTotalCosts";
 import "./Costs.css";
 
 interface CostsProps {
@@ -41,4 +41,3 @@ export function Costs({ costs }: CostsProps) {
     </table>
   );
 }
-

--- a/src/components/react/forms/Costs/index.ts
+++ b/src/components/react/forms/Costs/index.ts
@@ -1,2 +1,1 @@
 export * from "./Costs";
-

--- a/src/components/react/forms/Costs/index.ts
+++ b/src/components/react/forms/Costs/index.ts
@@ -1,0 +1,2 @@
+export * from "./Costs";
+

--- a/src/components/react/forms/FormContainer/FormContainer.tsx
+++ b/src/components/react/forms/FormContainer/FormContainer.tsx
@@ -5,6 +5,7 @@ import { FormReviewStep } from "@/components/react/forms/FormReviewStep";
 import { FormTitleStep } from "@/components/react/forms/FormTitleStep/FormTitleStep";
 import type { FieldName, FormData } from "@/constants/fields";
 import type { FormPdfMetadata } from "@/utils/getFormPdfMetadata";
+import type { Cost } from "@/utils/formatTotalCosts";
 import { FormStepContext } from "./FormStepContext";
 import "./FormContainer.css";
 
@@ -41,6 +42,9 @@ export interface FormContainerProps {
 
   /** The PDF metadata for forms that will be generated. */
   pdfs?: FormPdfMetadata[];
+
+  /** The costs associated with this form. */
+  costs?: Cost[];
 }
 
 export function FormContainer({
@@ -51,6 +55,7 @@ export function FormContainer({
   onSubmit,
   updatedAt,
   pdfs,
+  costs,
 }: FormContainerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -271,6 +276,7 @@ export function FormContainer({
       isReviewStep,
       isReviewingMode,
       onSubmit: handleFormSubmit,
+      costs,
     }),
     [
       goToNextStep,
@@ -282,6 +288,7 @@ export function FormContainer({
       isReviewStep,
       isReviewingMode,
       handleFormSubmit,
+      costs,
     ],
   );
 

--- a/src/components/react/forms/FormContainer/FormContainer.tsx
+++ b/src/components/react/forms/FormContainer/FormContainer.tsx
@@ -4,8 +4,8 @@ import { FormNavigation } from "@/components/react/forms/FormNavigation";
 import { FormReviewStep } from "@/components/react/forms/FormReviewStep";
 import { FormTitleStep } from "@/components/react/forms/FormTitleStep/FormTitleStep";
 import type { FieldName, FormData } from "@/constants/fields";
-import type { FormPdfMetadata } from "@/utils/getFormPdfMetadata";
 import type { Cost } from "@/utils/formatTotalCosts";
+import type { FormPdfMetadata } from "@/utils/getFormPdfMetadata";
 import { FormStepContext } from "./FormStepContext";
 import "./FormContainer.css";
 

--- a/src/components/react/forms/FormContainer/FormStepContext.tsx
+++ b/src/components/react/forms/FormContainer/FormStepContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext } from "react";
+import type { Cost } from "@/utils/formatTotalCosts";
 
 export interface FormStepContextValue {
   onNext: () => void;
@@ -17,6 +18,8 @@ export interface FormStepContextValue {
   isReviewingMode: boolean;
   /** Submit handler for form steps */
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  /** The costs associated with this form */
+  costs?: Cost[];
 }
 
 export const FormStepContext = createContext<FormStepContextValue | null>(null);

--- a/src/components/react/forms/FormNavigation/FormNavigation.css
+++ b/src/components/react/forms/FormNavigation/FormNavigation.css
@@ -2,7 +2,7 @@
   background: var(--background-color);
   display: flex;
   align-items: center;
-  gap: var(--space-l);
+  gap: var(--space-m);
   padding-block: var(--space-m);
   position: sticky;
   top: 0;
@@ -21,7 +21,7 @@
 .form-navigation-buttons {
   display: flex;
   align-items: center;
-  gap: var(--space-s);
+  gap: var(--space-xs);
 }
 
 .form-navigation-button {

--- a/src/components/react/forms/FormNavigation/FormNavigation.tsx
+++ b/src/components/react/forms/FormNavigation/FormNavigation.tsx
@@ -23,15 +23,6 @@ export const FormNavigation = memo(function FormNavigation() {
 
   return (
     <nav className="form-navigation">
-      <div className="form-progress">
-        <ProgressBar
-          label={formTitle}
-          value={isReviewStep ? totalSteps : currentStepIndex}
-          valueLabel={<Fragment />}
-          maxValue={isReviewStep ? totalSteps : totalSteps + 1}
-          formatOptions={{ style: "decimal" }}
-        />
-      </div>
       <div className="form-navigation-buttons">
         <Button
           onPress={onBack}
@@ -47,6 +38,15 @@ export const FormNavigation = memo(function FormNavigation() {
           aria-label="Next step"
           className="form-navigation-button"
           isDisabled={isReviewStep}
+        />
+      </div>
+      <div className="form-progress">
+        <ProgressBar
+          label={formTitle}
+          value={isReviewStep ? totalSteps : currentStepIndex}
+          valueLabel={<Fragment />}
+          maxValue={isReviewStep ? totalSteps : totalSteps + 1}
+          formatOptions={{ style: "decimal" }}
         />
       </div>
     </nav>

--- a/src/components/react/forms/FormTitleStep/FormTitleStep.tsx
+++ b/src/components/react/forms/FormTitleStep/FormTitleStep.tsx
@@ -7,7 +7,7 @@ import {
   RiTimerLine,
 } from "@remixicon/react";
 import { useEffect, useState } from "react";
-import { UAParser } from "ua-parser-js";
+import { UAParser, type IBrowser, type IDevice } from "ua-parser-js";
 import { formatTimeEstimate } from "@/utils/formatTimeEstimate";
 import type { FormPdfMetadata } from "@/utils/getFormPdfMetadata";
 import { smartquotes } from "@/utils/smartquotes";
@@ -16,6 +16,8 @@ import "./FormTitleStep.css";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { Heading } from "../../common/Content/Content";
+import { formatBrowser } from "@/utils/formatBrowser";
+import { formatDevice } from "@/utils/formatDevice";
 
 dayjs.extend(utc);
 
@@ -85,12 +87,14 @@ export function FormTitleStep({
   totalSteps,
   updatedAt,
 }: FormTitleStepProps) {
-  const [userAgent, setUserAgent] = useState<UAParser.IResult | null>(null);
+  const [device, setDevice] = useState<IDevice | null>(null);
+  const [browser, setBrowser] = useState<IBrowser | null>(null);
   const timeEstimate = formatTimeEstimate(totalSteps);
 
   useEffect(() => {
     if (typeof navigator !== "undefined") {
-      setUserAgent(UAParser(navigator.userAgent));
+      setDevice(UAParser(navigator.userAgent).device);
+      setBrowser(UAParser(navigator.userAgent).browser);
     }
   }, []);
 
@@ -140,8 +144,8 @@ export function FormTitleStep({
         <FormInfoItem icon={RiShieldKeyholeLine}>
           <FormInfoItemTitle>
             Responses are securely stored in{" "}
-            <strong>{userAgent?.browser.name ?? "this browser"}</strong> on{" "}
-            <strong>this {userAgent?.device.model ?? "device"}</strong>.
+            <strong>{formatBrowser(browser)}</strong> on{" "}
+            <strong>{formatDevice(device)}</strong>.
           </FormInfoItemTitle>
           <FormInfoItemDescription>
             For security, your information never leaves this device.

--- a/src/components/react/forms/FormTitleStep/FormTitleStep.tsx
+++ b/src/components/react/forms/FormTitleStep/FormTitleStep.tsx
@@ -7,7 +7,7 @@ import {
   RiTimerLine,
 } from "@remixicon/react";
 import { useEffect, useState } from "react";
-import { UAParser, type IBrowser, type IDevice } from "ua-parser-js";
+import { type IBrowser, type IDevice, UAParser } from "ua-parser-js";
 import { formatTimeEstimate } from "@/utils/formatTimeEstimate";
 import type { FormPdfMetadata } from "@/utils/getFormPdfMetadata";
 import { smartquotes } from "@/utils/smartquotes";
@@ -15,9 +15,9 @@ import { Button } from "../../common/Button";
 import "./FormTitleStep.css";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
-import { Heading } from "../../common/Content/Content";
 import { formatBrowser } from "@/utils/formatBrowser";
 import { formatDevice } from "@/utils/formatDevice";
+import { Heading } from "../../common/Content/Content";
 
 dayjs.extend(utc);
 

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -121,6 +121,7 @@ const headerDescription =
 
 <style lang="scss" is:global>
   .article-grid {
+    padding-block-end: var(--space-2xl);
     display: grid;
     grid-auto-rows: minmax(min-content, max-content);
     column-gap: var(--space-m);

--- a/src/pages/forms/court-order-ma/_Form.tsx
+++ b/src/pages/forms/court-order-ma/_Form.tsx
@@ -2,6 +2,7 @@ import { FormContainer } from "@/components/react/forms/FormContainer";
 import type { FieldType } from "@/constants/fields";
 import { createFormSubmitHandler } from "@/utils/createFormSubmitHandler";
 import type { FormPdfMetadata } from "@/utils/getFormPdfMetadata";
+import type { Cost } from "@/utils/formatTotalCosts";
 import { useForm } from "@/utils/useForm";
 import { courtOrderMaConfig } from "./config";
 
@@ -14,11 +15,13 @@ export function MaCourtOrderForm({
   description,
   updatedAt,
   pdfs,
+  costs,
 }: {
   title: string;
   description: string;
   updatedAt?: string;
   pdfs?: FormPdfMetadata[];
+  costs?: Cost[];
 }) {
   const { ...form } = useForm<FormData>(courtOrderMaConfig.fields);
 
@@ -33,6 +36,7 @@ export function MaCourtOrderForm({
       onSubmit={handleSubmit}
       updatedAt={updatedAt}
       pdfs={pdfs}
+      costs={costs}
     />
   );
 }

--- a/src/pages/forms/court-order-ma/_Form.tsx
+++ b/src/pages/forms/court-order-ma/_Form.tsx
@@ -1,8 +1,8 @@
 import { FormContainer } from "@/components/react/forms/FormContainer";
 import type { FieldType } from "@/constants/fields";
 import { createFormSubmitHandler } from "@/utils/createFormSubmitHandler";
-import type { FormPdfMetadata } from "@/utils/getFormPdfMetadata";
 import type { Cost } from "@/utils/formatTotalCosts";
+import type { FormPdfMetadata } from "@/utils/getFormPdfMetadata";
 import { useForm } from "@/utils/useForm";
 import { courtOrderMaConfig } from "./config";
 

--- a/src/pages/forms/court-order-ma/_steps/AddressStep.tsx
+++ b/src/pages/forms/court-order-ma/_steps/AddressStep.tsx
@@ -7,7 +7,7 @@ export const addressStep: StepConfig = {
   id: "address",
   title: "What is your residential address?",
   description:
-    "You must reside in the same county where you file your name change. We'll help you find where to file.",
+    "You must file your name change in the county where you live. We'll help you find where to file.",
   fields: [
     "isCurrentlyUnhoused",
     "residenceStreetAddress",

--- a/src/pages/forms/court-order-ma/_steps/ContactInfoStep.tsx
+++ b/src/pages/forms/court-order-ma/_steps/ContactInfoStep.tsx
@@ -6,7 +6,8 @@ import { PhoneField } from "@/components/react/forms/PhoneField";
 export const contactInfoStep: StepConfig = {
   id: "contact-info",
   title: "What is your contact information?",
-  description: "The court uses this to communicate with you about your status.",
+  description:
+    "The court uses this to communicate with you about your filing status.",
   fields: ["phoneNumber", "email"],
   component: ({ stepConfig }) => (
     <FormStep stepConfig={stepConfig}>

--- a/src/pages/forms/court-order-ma/_steps/DateOfBirthStep.tsx
+++ b/src/pages/forms/court-order-ma/_steps/DateOfBirthStep.tsx
@@ -5,7 +5,6 @@ import { MemorableDateField } from "@/components/react/forms/MemorableDateField"
 export const dateOfBirthStep: StepConfig = {
   id: "date-of-birth",
   title: "What is your date of birth?",
-  description: "This is your date of birth.",
   fields: ["dateOfBirth"],
   component: ({ stepConfig }) => (
     <FormStep stepConfig={stepConfig}>

--- a/src/pages/forms/court-order-ma/_steps/FeeWaiverStep.tsx
+++ b/src/pages/forms/court-order-ma/_steps/FeeWaiverStep.tsx
@@ -1,11 +1,11 @@
 import { Banner } from "@/components/react/common/Banner";
+import { Costs } from "@/components/react/forms/Costs";
 import {
-  useFormStep,
   type StepConfig,
+  useFormStep,
 } from "@/components/react/forms/FormContainer";
 import { FormStep } from "@/components/react/forms/FormStep";
 import { YesNoField } from "@/components/react/forms/YesNoField";
-import { Costs } from "@/components/react/forms/Costs";
 
 export const feeWaiverStep: StepConfig = {
   id: "fee-waiver",

--- a/src/pages/forms/court-order-ma/_steps/FeeWaiverStep.tsx
+++ b/src/pages/forms/court-order-ma/_steps/FeeWaiverStep.tsx
@@ -1,7 +1,11 @@
 import { Banner } from "@/components/react/common/Banner";
-import type { StepConfig } from "@/components/react/forms/FormContainer";
+import {
+  useFormStep,
+  type StepConfig,
+} from "@/components/react/forms/FormContainer";
 import { FormStep } from "@/components/react/forms/FormStep";
 import { YesNoField } from "@/components/react/forms/YesNoField";
+import { Costs } from "@/components/react/forms/Costs";
 
 export const feeWaiverStep: StepConfig = {
   id: "fee-waiver",
@@ -9,37 +13,38 @@ export const feeWaiverStep: StepConfig = {
   description:
     "If you are unable to pay the filing fee, you can file an Affidavit of Indigency—a document proving that you are unable to pay.",
   fields: ["shouldApplyForFeeWaiver"],
-  component: ({ stepConfig, form }) => (
-    <FormStep stepConfig={stepConfig}>
-      <YesNoField
-        name="shouldApplyForFeeWaiver"
-        label="Apply for a fee waiver?"
-        labelHidden
-        yesLabel="Yes, help me waive filing fees"
-        noLabel="No, I will pay the filing fee"
-      />
-      {form.watch("shouldApplyForFeeWaiver") === true ? (
-        <Banner>
-          Your download will include an Affidavit of Indigency.{" "}
-          <strong>
-            There are additional fields in the download you have to fill out.
-          </strong>{" "}
-          Additionally, you can{" "}
-          <a
-            href="https://www.masstpc.org/what-we-do/ida-network/ida-financial-assistance/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            request financial assistance through the Massachusetts Transgender
-            Political Coalition.
-          </a>
-        </Banner>
-      ) : (
-        <Banner>
-          {/* TODO: Add QuestCostsTable component when available */}
-          <p>Filing fees apply. See court costs for details.</p>
-        </Banner>
-      )}
-    </FormStep>
-  ),
+  component: ({ stepConfig, form }) => {
+    const { costs } = useFormStep();
+
+    return (
+      <FormStep stepConfig={stepConfig}>
+        <YesNoField
+          name="shouldApplyForFeeWaiver"
+          label="Apply for a fee waiver?"
+          labelHidden
+          yesLabel="Yes, help me waive filing fees"
+          noLabel="No, I will pay the filing fee"
+        />
+        {form.watch("shouldApplyForFeeWaiver") === true ? (
+          <Banner>
+            Your download will include an Affidavit of Indigency.{" "}
+            <strong>
+              There are additional fields in the download you have to fill out.
+            </strong>{" "}
+            Additionally, you can{" "}
+            <a
+              href="https://www.masstpc.org/what-we-do/ida-network/ida-financial-assistance/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              request financial assistance through the Massachusetts Transgender
+              Political Coalition.
+            </a>
+          </Banner>
+        ) : (
+          <Costs costs={costs ?? []} />
+        )}
+      </FormStep>
+    );
+  },
 };

--- a/src/pages/forms/court-order-ma/index.astro
+++ b/src/pages/forms/court-order-ma/index.astro
@@ -6,7 +6,14 @@ import { getFormPdfMetadata } from "@/utils/getFormPdfMetadata";
 import { MaCourtOrderForm } from "./_Form";
 
 const { data: form } = await loadQuery<SanityDocument>({
-  query: `*[_type == "form" && slug.current == $slug][0]`,
+  query: `*[_type == "form" && slug.current == $slug][0]{
+    title,
+    description,
+    _updatedAt,
+    state,
+    category,
+    "costs": *[_type == "guide" && state._ref == ^.state._ref && category._ref == ^.category._ref][0].costs
+  }`,
   params: {
     slug: "court-order-ma",
   },
@@ -22,5 +29,6 @@ const pdfs = await getFormPdfMetadata("court-order-ma");
     description={form.description}
     updatedAt={form._updatedAt}
     pdfs={pdfs}
+    costs={form.costs}
   />
 </BaseLayout>

--- a/src/utils/__tests__/formatBrowser.test.ts
+++ b/src/utils/__tests__/formatBrowser.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { formatBrowser } from "../formatBrowser";
+
+describe("formatBrowser", () => {
+  it("should return the browser name when available", () => {
+    expect(formatBrowser({ name: "Chrome" })).toBe("Chrome");
+    expect(formatBrowser({ name: "Firefox" })).toBe("Firefox");
+    expect(formatBrowser({ name: "Safari" })).toBe("Safari");
+  });
+
+  it("should return 'this browser' when null is provided", () => {
+    expect(formatBrowser(null)).toBe("this browser");
+  });
+
+  it("should return 'this browser' when name is undefined", () => {
+    expect(formatBrowser({})).toBe("this browser");
+    expect(formatBrowser({ name: undefined })).toBe("this browser");
+  });
+
+  it("should return 'this browser' when name is empty string", () => {
+    expect(formatBrowser({ name: "" })).toBe("this browser");
+  });
+});

--- a/src/utils/__tests__/formatDevice.test.ts
+++ b/src/utils/__tests__/formatDevice.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { formatDevice } from "../formatDevice";
+
+describe("formatDevice", () => {
+  it("should return 'this device' when null is provided", () => {
+    expect(formatDevice(null)).toBe("this device");
+  });
+
+  it("should return 'this device' when empty object is provided", () => {
+    expect(formatDevice({})).toBe("this device");
+  });
+
+  it("should return vendor and model when both are provided", () => {
+    expect(
+      formatDevice({ type: "mobile", vendor: "Apple", model: "iPhone" }),
+    ).toBe("this Apple iPhone");
+    expect(formatDevice({ vendor: "Samsung", model: "Galaxy S23" })).toBe(
+      "this Samsung Galaxy S23",
+    );
+  });
+
+  it("should return just the vendor when model is not provided", () => {
+    expect(formatDevice({ vendor: "Apple" })).toBe("this Apple");
+    expect(formatDevice({ vendor: "Samsung" })).toBe("this Samsung");
+  });
+
+  it("should return 'this device' when only model is provided without vendor", () => {
+    expect(formatDevice({ model: "iPhone" })).toBe("this device");
+  });
+
+  it("should return 'this device' when vendor is undefined", () => {
+    expect(formatDevice({ vendor: undefined, model: "iPhone" })).toBe(
+      "this device",
+    );
+  });
+});

--- a/src/utils/formatBrowser.ts
+++ b/src/utils/formatBrowser.ts
@@ -1,0 +1,5 @@
+import type { IBrowser } from "ua-parser-js";
+
+export function formatBrowser(browser: Partial<IBrowser> | null) {
+  return browser?.name || "this browser";
+}

--- a/src/utils/formatDevice.ts
+++ b/src/utils/formatDevice.ts
@@ -1,0 +1,15 @@
+import type { IDevice } from "ua-parser-js";
+
+export function formatDevice(device: Partial<IDevice> | null) {
+  let deviceName = "device";
+
+  if (device?.vendor) {
+    if (device.model) {
+      deviceName = `${device.vendor} ${device.model}`;
+    } else {
+      deviceName = device.vendor;
+    }
+  }
+
+  return `this ${deviceName}`;
+}


### PR DESCRIPTION
- Improve display of device and browser name with new (unit-tested!) utils
- Move "back" and "next" buttons to the top left of the progress bar for easier visibility of "back"
- Add costs table to MA Court Order
- Remove redundant subhead from DOB page
- Clarify "status" as "filing status" on contact info page
- Remove `typed-usa-states` import since dynamic loading was sometimes failing; will ship a future improvement to hit a census API endpoint to fetch counties and autopopulate address fields