### PR TITLE
Remove waiver steps from MA Court Order

### DIFF
--- a/src/components/react/forms/FormContainer/FormContainer.tsx
+++ b/src/components/react/forms/FormContainer/FormContainer.tsx
@@ -28,6 +28,9 @@ export interface FormContainerProps {
   /** An optional description to provide more context. */
   description?: string;
 
+  /** Children to display on the title step. */
+  children?: React.ReactNode;
+
   /** The form steps to render. */
   steps: readonly StepConfig[];
 
@@ -50,6 +53,7 @@ export interface FormContainerProps {
 export function FormContainer({
   title,
   description,
+  children,
   steps,
   form,
   onSubmit,
@@ -240,7 +244,9 @@ export function FormContainer({
               window.location.hash = steps[0].id;
             }
           }}
-        />
+        >
+          {children}
+        </FormTitleStep>
       );
     }
 
@@ -255,7 +261,16 @@ export function FormContainer({
     }
 
     return null;
-  }, [navigationIndex, steps, form, pdfs, updatedAt, title, description]);
+  }, [
+    navigationIndex,
+    steps,
+    form,
+    pdfs,
+    updatedAt,
+    title,
+    description,
+    children,
+  ]);
 
   // Calculate the current step index for the context (1-based for actual steps, 0 for title/review)
   const currentStepIndex =

--- a/src/components/react/forms/FormTitleStep/FormTitleStep.css
+++ b/src/components/react/forms/FormTitleStep/FormTitleStep.css
@@ -13,7 +13,9 @@
   text-decoration: none;
   color: var(--text-color);
   font-size: var(--step-0);
-  padding-block-end: var(--space-s);
+  padding-inline-end: var(--space-2xs);
+  margin-inline-start: calc(-1 * var(--space-2xs));
+  margin-block-end: var(--space-s);
 
   @media (hover: hover) {
     &:hover {
@@ -24,6 +26,7 @@
 
 .form-title-step-header {
   display: flex;
+  align-items: flex-start;
   flex-direction: column;
 }
 

--- a/src/components/react/forms/FormTitleStep/FormTitleStep.tsx
+++ b/src/components/react/forms/FormTitleStep/FormTitleStep.tsx
@@ -59,6 +59,11 @@ export interface FormTitleStepProps {
   description?: string;
 
   /**
+   * Child content.
+   */
+  children?: React.ReactNode;
+
+  /**
    * Handler for when the user clicks the start button.
    */
   onStart: () => void;
@@ -82,6 +87,7 @@ export interface FormTitleStepProps {
 export function FormTitleStep({
   title,
   description,
+  children,
   onStart,
   pdfs,
   totalSteps,
@@ -113,6 +119,7 @@ export function FormTitleStep({
           </p>
         )}
       </header>
+      {children}
       <FormInfo>
         <FormInfoItem icon={RiFileCheckLine}>
           <FormInfoItemTitle>

--- a/src/pages/forms/court-order-ma/_Form.tsx
+++ b/src/pages/forms/court-order-ma/_Form.tsx
@@ -1,3 +1,5 @@
+import { RiMegaphoneLine } from "@remixicon/react";
+import { Banner } from "@/components/react/common/Banner";
 import { FormContainer } from "@/components/react/forms/FormContainer";
 import type { FieldType } from "@/constants/fields";
 import { createFormSubmitHandler } from "@/utils/createFormSubmitHandler";
@@ -5,9 +7,6 @@ import type { Cost } from "@/utils/formatTotalCosts";
 import type { FormPdfMetadata } from "@/utils/getFormPdfMetadata";
 import { useForm } from "@/utils/useForm";
 import { courtOrderMaConfig } from "./config";
-import { Banner } from "@/components/react/common/Banner";
-import { Link } from "@/components/react/common/Link";
-import { RiMegaphoneLine } from "@remixicon/react";
 
 type FormData = {
   [K in (typeof courtOrderMaConfig.fields)[number]]: FieldType<K>;

--- a/src/pages/forms/court-order-ma/_Form.tsx
+++ b/src/pages/forms/court-order-ma/_Form.tsx
@@ -5,6 +5,9 @@ import type { Cost } from "@/utils/formatTotalCosts";
 import type { FormPdfMetadata } from "@/utils/getFormPdfMetadata";
 import { useForm } from "@/utils/useForm";
 import { courtOrderMaConfig } from "./config";
+import { Banner } from "@/components/react/common/Banner";
+import { Link } from "@/components/react/common/Link";
+import { RiMegaphoneLine } from "@remixicon/react";
 
 type FormData = {
   [K in (typeof courtOrderMaConfig.fields)[number]]: FieldType<K>;
@@ -37,6 +40,20 @@ export function MaCourtOrderForm({
       updatedAt={updatedAt}
       pdfs={pdfs}
       costs={costs}
-    />
+    >
+      <Banner icon={RiMegaphoneLine}>
+        Massachusetts no longer requires publishing name change in a newspaper
+        as of November 26, 2025. All name change records will now be kept
+        confidential without having to file additional paperwork.{" "}
+        <a
+          href="https://www.masstpc.org/name-change-bill-signed/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Read more about the passage of MA Senate Bill 1045 and House Bill
+          1673, "An Act Protecting Personal Security".
+        </a>
+      </Banner>
+    </FormContainer>
   );
 }

--- a/src/pages/forms/court-order-ma/config.ts
+++ b/src/pages/forms/court-order-ma/config.ts
@@ -5,7 +5,6 @@ import { contactInfoStep } from "./_steps/ContactInfoStep";
 import { currentNameStep } from "./_steps/CurrentNameStep";
 import { dateOfBirthStep } from "./_steps/DateOfBirthStep";
 import { feeWaiverStep } from "./_steps/FeeWaiverStep";
-import { impoundCaseStep } from "./_steps/ImpoundCaseStep";
 import { interpreterStep } from "./_steps/InterpreterStep";
 import { mothersMaidenNameStep } from "./_steps/MothersMaidenNameStep";
 import { newNameStep } from "./_steps/NewNameStep";
@@ -14,7 +13,6 @@ import { previousNameChangeStep } from "./_steps/PreviousNameChangeStep";
 import { pronounsStep } from "./_steps/PronounsStep";
 import { reasonStep } from "./_steps/ReasonStep";
 import { returnDocumentsStep } from "./_steps/ReturnDocumentsStep";
-import { waivePublicationStep } from "./_steps/WaivePublicationStep";
 
 const STEPS = [
   newNameStep,
@@ -29,8 +27,6 @@ const STEPS = [
   interpreterStep,
   pronounsStep,
   returnDocumentsStep,
-  waivePublicationStep,
-  impoundCaseStep,
   feeWaiverStep,
   mothersMaidenNameStep,
 ] as const;
@@ -44,14 +40,6 @@ export const courtOrderMaConfig = {
   pdfs: [
     { pdfId: "cjp27-petition-to-change-name-of-adult" },
     { pdfId: "cjp34-cori-and-wms-release-request" },
-    {
-      pdfId: "cjd400-motion-to-waive-publication",
-      include: (data) => data.shouldWaivePublicationRequirement === true,
-    },
-    {
-      pdfId: "cjd400-motion-to-impound-records",
-      include: (data) => data.shouldImpoundCourtRecords === true,
-    },
     {
       pdfId: "affidavit-of-indigency",
       include: (data) => data.shouldApplyForFeeWaiver === true,


### PR DESCRIPTION
[An Act Protecting Personal Security](https://www.masstpc.org/name-change-bill-signed/) has been passed and the waiver steps are no longer needed. Removes them from the MA Court Order flow and adds a banner to the title step explaining the change.