### PR TITLE
Display forms and guides in top nav

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -7,6 +7,8 @@ const paths = [
   "/about",
   "/blog",
   "/brand-assets",
+  "/forms",
+  "/guides",
   "/press",
   "/privacy",
   "/terms",

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -21,7 +21,7 @@ const linkGroups: LinkGroup[] = [
   {
     title: "About",
     links: [
-      { href: "/blog", label: "Blog" },
+      { href: siteInfo.urls.blog, label: "Blog" },
       { href: "/press", label: "Press" },
       { href: "/brand-assets", label: "Brand" },
       { href: siteInfo.urls.donate, label: "Donate" },

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -24,6 +24,7 @@ const linkGroups: LinkGroup[] = [
       { href: "/blog", label: "Blog" },
       { href: "/press", label: "Press" },
       { href: "/brand-assets", label: "Brand" },
+      { href: siteInfo.urls.donate, label: "Donate" },
     ],
   },
   {
@@ -37,8 +38,9 @@ const linkGroups: LinkGroup[] = [
   {
     title: "Resources",
     links: [
+      { href: siteInfo.urls.guides, label: "Guides" },
+      { href: siteInfo.urls.forms, label: "Forms" },
       { href: siteInfo.urls.chat, label: "Chat" },
-      { href: siteInfo.urls.donate, label: "Donate" },
       { href: siteInfo.urls.status, label: "Status" },
     ],
   },

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,6 @@
 ---
-import Logo from "./Logo.astro";
 import siteInfo from "@/constants/site-info";
+import Logo from "./Logo.astro";
 
 const { pathname } = Astro.url;
 
@@ -53,10 +53,6 @@ const navLinks = [
     width: 100%;
     max-width: 1200px;
     margin-inline: auto;
-
-    @media (width > 520px) {
-      flex-direction: row;
-    }
   }
 
   #logo {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,37 +1,32 @@
 ---
-import siteInfo from "@/constants/site-info";
 import Logo from "./Logo.astro";
 
-const { urls } = siteInfo;
 const { pathname } = Astro.url;
+
+const navLinks = [
+  { href: "/guides", ariaCurrent: "guides", label: "Guides" },
+  { href: "/forms", ariaCurrent: "forms", label: "Forms" },
+  { href: "/blog", ariaCurrent: "blog", label: "Blog" },
+  { href: "/donate", ariaCurrent: "donate", label: "Donate" },
+];
 ---
 
 <header>
   <a href="/" aria-label="Home" id="logo"><Logo /></a>
   <nav aria-label="Site">
     <ul role="list">
-      <li>
-        <a
-          href="/guides"
-          aria-current={pathname.slice(1).startsWith("guides")
-            ? "page"
-            : "false"}>Guides</a>
-      </li>
-      <li>
-        <a
-          href="/forms"
-          aria-current={pathname.slice(1).startsWith("forms")
-            ? "page"
-            : "false"}>Forms</a>
-      </li>
-      <li>
-        <a
-          href="/blog"
-          aria-current={pathname.slice(1).startsWith("blog") ? "page" : "false"}
-          >Blog</a
-        >
-      </li>
-      <li><a href="/donate">Donate</a></li>
+      {
+        navLinks.map(({ href, ariaCurrent, label }) => (
+          <li>
+            <a
+              href={href}
+              aria-current={ariaCurrent === pathname ? "page" : "false"}
+            >
+              {label}
+            </a>
+          </li>
+        ))
+      }
     </ul>
   </nav>
 </header>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,13 +1,14 @@
 ---
 import Logo from "./Logo.astro";
+import siteInfo from "@/constants/site-info";
 
 const { pathname } = Astro.url;
 
 const navLinks = [
-  { href: "/guides", label: "Guides" },
-  { href: "/forms", label: "Forms" },
-  { href: "/blog", label: "Blog" },
-  { href: "/donate", label: "Donate" },
+  { href: siteInfo.urls.guides, label: "Guides" },
+  { href: siteInfo.urls.forms, label: "Forms" },
+  { href: siteInfo.urls.blog, label: "Blog" },
+  { href: siteInfo.urls.donate, label: "Donate" },
 ];
 ---
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,10 +4,10 @@ import Logo from "./Logo.astro";
 const { pathname } = Astro.url;
 
 const navLinks = [
-  { href: "/guides", ariaCurrent: "guides", label: "Guides" },
-  { href: "/forms", ariaCurrent: "forms", label: "Forms" },
-  { href: "/blog", ariaCurrent: "blog", label: "Blog" },
-  { href: "/donate", ariaCurrent: "donate", label: "Donate" },
+  { href: "/guides", label: "Guides" },
+  { href: "/forms", label: "Forms" },
+  { href: "/blog", label: "Blog" },
+  { href: "/donate", label: "Donate" },
 ];
 ---
 
@@ -16,11 +16,11 @@ const navLinks = [
   <nav aria-label="Site">
     <ul role="list">
       {
-        navLinks.map(({ href, ariaCurrent, label }) => (
+        navLinks.map(({ href, label }) => (
           <li>
             <a
               href={href}
-              aria-current={ariaCurrent === pathname ? "page" : "false"}
+              aria-current={pathname.startsWith(href) ? "page" : "false"}
             >
               {label}
             </a>
@@ -44,23 +44,31 @@ const navLinks = [
   header {
     top: 0;
     display: flex;
+    flex-wrap: wrap;
     align-items: baseline;
     justify-content: space-between;
     padding: var(--space-l);
+    gap: var(--space-l);
     width: 100%;
     max-width: 1200px;
     margin-inline: auto;
+
+    @media (width > 520px) {
+      flex-direction: row;
+    }
   }
 
   #logo {
-    transform: translateY(2px);
+    transform: translateY(1px);
   }
 
   ul {
     list-style: none;
     display: flex;
+    flex-wrap: wrap;
     padding: unset;
     margin: unset;
+    margin-inline-start: calc(var(--space-s) * -1);
 
     a {
       padding: var(--space-xs) var(--space-s);

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -12,13 +12,26 @@ const { pathname } = Astro.url;
     <ul role="list">
       <li>
         <a
+          href="/guides"
+          aria-current={pathname.slice(1).startsWith("guides")
+            ? "page"
+            : "false"}>Guides</a>
+      </li>
+      <li>
+        <a
+          href="/forms"
+          aria-current={pathname.slice(1).startsWith("forms")
+            ? "page"
+            : "false"}>Forms</a>
+      </li>
+      <li>
+        <a
           href="/blog"
           aria-current={pathname.slice(1).startsWith("blog") ? "page" : "false"}
           >Blog</a
         >
       </li>
       <li><a href="/donate">Donate</a></li>
-      <li><a href={urls.app}>Sign In</a></li>
     </ul>
   </nav>
 </header>

--- a/src/components/SupportMap.astro
+++ b/src/components/SupportMap.astro
@@ -238,8 +238,34 @@ function getFillForSupportLevel(supportLevel: string): string {
   updatePatternScales();
   window.addEventListener("resize", updatePatternScales);
 
+  function positionTooltip(event: MouseEvent) {
+    const tooltipNode = tooltip.node() as HTMLElement;
+    const containerNode = container.node() as HTMLElement;
+    const tooltipRect = tooltipNode.getBoundingClientRect();
+    const containerRect = containerNode.getBoundingClientRect();
+
+    const containerX = event.clientX - containerRect.left;
+    const containerY = event.clientY - containerRect.top;
+
+    let left = containerX + 16;
+    let top = containerY + 16;
+
+    if (left < 0) left = 16;
+    if (top < 0) top = 16;
+    if (left + tooltipRect.width > containerRect.width) {
+      left = containerRect.width - tooltipRect.width - 16;
+    }
+
+    tooltip.style("top", top + "px").style("left", left + "px");
+  }
+
+  function clearHoverState() {
+    states.attr("data-hovered", null);
+    tooltip.attr("data-visible", null);
+  }
+
   states
-    .on("mouseover", function () {
+    .on("mouseenter", function (event: MouseEvent) {
       const element = this as SVGPathElement;
       const stateName = element.getAttribute("data-name") || "";
       const supportLevel = element.getAttribute("data-support") || "none";
@@ -252,6 +278,7 @@ function getFillForSupportLevel(supportLevel: string): string {
       const supportText =
         textMap[supportLevel as keyof typeof textMap] || "No Support Yet";
 
+      states.attr("data-hovered", null);
       const hoveredState = d3.select(this);
       hoveredState.attr("data-hovered", "true");
 
@@ -261,31 +288,19 @@ function getFillForSupportLevel(supportLevel: string): string {
       tooltip
         .attr("data-visible", "true")
         .html(`<strong>${stateName}</strong><br/>${supportText}`);
+      positionTooltip(event);
     })
     .on("mousemove", function (event: MouseEvent) {
-      const tooltipNode = tooltip.node() as HTMLElement;
-      const containerNode = container.node() as HTMLElement;
-      const tooltipRect = tooltipNode.getBoundingClientRect();
-      const containerRect = containerNode.getBoundingClientRect();
-
-      const containerX = event.clientX - containerRect.left;
-      const containerY = event.clientY - containerRect.top;
-
-      let left = containerX + 16;
-      let top = containerY + 16;
-
-      if (left < 0) left = 16;
-      if (top < 0) top = 16;
-      if (left + tooltipRect.width > containerRect.width) {
-        left = containerRect.width - tooltipRect.width - 16;
-      }
-
-      tooltip.style("top", top + "px").style("left", left + "px");
+      positionTooltip(event);
     })
-    .on("mouseout", function () {
-      states.attr("data-hovered", null);
+    .on("mouseleave", function () {
+      d3.select(this).attr("data-hovered", null);
       tooltip.attr("data-visible", null);
     });
+
+  svg.on("mouseleave", function () {
+    clearHoverState();
+  });
 
   legendItems
     .on("mouseover", function () {

--- a/src/constants/site-info.ts
+++ b/src/constants/site-info.ts
@@ -39,7 +39,8 @@ export type SiteInfo = {
     alt: string;
   };
   urls: {
-    app: string;
+    guides: string;
+    forms: string;
     chat: string;
     status: string;
     donate: string;
@@ -58,7 +59,8 @@ const siteInfo: SiteInfo = {
     url: "https://superbloom.design/",
   },
   urls: {
-    app: "https://app.namesake.fyi",
+    guides: "/guides",
+    forms: "/forms",
     chat: "/chat",
     status: "/status",
     donate: "/donate",

--- a/src/constants/site-info.ts
+++ b/src/constants/site-info.ts
@@ -41,6 +41,7 @@ export type SiteInfo = {
   urls: {
     guides: string;
     forms: string;
+    blog: string;
     chat: string;
     status: string;
     donate: string;
@@ -61,6 +62,7 @@ const siteInfo: SiteInfo = {
   urls: {
     guides: "/guides",
     forms: "/forms",
+    blog: "/blog",
     chat: "/chat",
     status: "/status",
     donate: "/donate",

--- a/src/pages/forms/index.astro
+++ b/src/pages/forms/index.astro
@@ -58,9 +58,9 @@ dayjs.extend(utc);
       formsWithPdfs.length ? (
         formsWithPdfs.map((form) => (
           <div class="form">
-            <h3>
+            <h2>
               <a href={`/forms/${form.slug.current}`}>{form.title}</a>
-            </h3>
+            </h2>
             <ul class="form-metadata">
               <li>
                 <RiFileCheckLine />{" "}
@@ -119,7 +119,7 @@ dayjs.extend(utc);
         5px 5px 0 -2px var(--border-color);
     }
 
-    h3 {
+    h2 {
       font-size: var(--step-1);
       line-height: var(--line-height-display);
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -61,8 +61,8 @@ if (!page) return Astro.redirect("/404");
     <section class="content">
       <PortableText value={page.content} />
       <div class="buttons">
-        <a href={siteInfo.urls.app} class="button primary"
-          >Get started <RiArrowRightLine className="icon" /></a
+        <a href={siteInfo.urls.guides} class="button primary"
+          >Browse guides <RiArrowRightLine className="icon" /></a
         >
         <a href={siteInfo.urls.chat}>Join us on Discord</a>
       </div>


### PR DESCRIPTION
- Add "Forms" and "Guides" to header and footer navigation
- Remove app.namesake.fyi "Get Started" link; replace with "Browse guides"
- Allow header links to wrap beneath when space is unavailable
- Fix an issue with tooltip positioning and state boundary outlines on the index

<img width="1464" height="1428" alt="CleanShot 2026-01-31 at 18 59 26@2x" src="https://github.com/user-attachments/assets/139e0d2f-fbd6-4c41-b654-b3ce007ccfb2" />
