### PR TITLE
Don't group major dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,3 @@ updates:
     groups:
       patch-minor:
         update-types: ["patch", "minor"]
-      major:
-        update-types: ["major"]


### PR DESCRIPTION
Allow reviewing major upgrades independently.