### PR TITLE
Update GitHub workflow permissions

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -21,6 +21,9 @@ on:
         "package.json",
       ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Playwright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -22,8 +25,7 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -49,8 +51,6 @@ jobs:
   test:
     name: Unit Test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   congrats:
     uses: namesakefyi/congratsbot/.github/workflows/congratsbot.yml@main

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -7,6 +7,10 @@ on:
     # Run once a week
     - cron: "0 0 * * 0"
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   link-checker:
     name: Check Link Validity


### PR DESCRIPTION
Add top-level permissions to all GitHub workflows lacking them in order to resolve code scanning warnings.