### PR TITLE
Fix RSS feed generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "fathom-client": "^3.7.2",
     "idb": "^8.0.3",
     "language-name-map": "^0.3.0",
-    "markdown-it": "^14.1.0",
     "postcss": "^8.5.6",
     "react": "^19.2.1",
     "react-aria-components": "^1.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,9 +104,6 @@ importers:
       language-name-map:
         specifier: ^0.3.0
         version: 0.3.0
-      markdown-it:
-        specifier: ^14.1.0
-        version: 14.1.0
       postcss:
         specifier: ^8.5.6
         version: 8.5.6

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -68,6 +68,12 @@ const pageTitle = Astro.url.pathname === "/" ? title : `${title} · Namesake`;
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="sitemap" href="/sitemap-index.xml" />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="Namesake"
+      href={new URL("rss.xml", Astro.site)}
+    />
   </head>
   <body data-color={color}>
     <Header />


### PR DESCRIPTION
Fixes #310.

Fetch posts from Sanity CMS and generate RSS feed. Additionally, add a new `<link>` within `<head>` to aid with automatic RSS discovery.