### PR TITLE
Add banner to link unhoused users to resources via MTPC

### DIFF
--- a/src/pages/forms/court-order-ma/_steps/AddressStep.tsx
+++ b/src/pages/forms/court-order-ma/_steps/AddressStep.tsx
@@ -1,3 +1,4 @@
+import { Banner } from "@/components/react/common/Banner";
 import { AddressField } from "@/components/react/forms/AddressField";
 import { CheckboxField } from "@/components/react/forms/CheckboxField";
 import type { StepConfig } from "@/components/react/forms/FormContainer";
@@ -58,6 +59,16 @@ export const addressStep: StepConfig = {
         name="isCurrentlyUnhoused"
         label="I am currently unhoused or without permanent housing"
       />
+      {form.watch("isCurrentlyUnhoused") === true && (
+        <Banner variant="info">
+          We recommend reaching out to the{" "}
+          <a href="https://www.masstpc.org/homelessness/">
+            Massachusetts Transgender Political Coalition
+          </a>
+          . MTPC may be able to provide an address to use for your name change
+          application and help you find housing.
+        </Banner>
+      )}
       {form.watch("isCurrentlyUnhoused") !== true && (
         <>
           <AddressField type="residence" includeCounty />

--- a/src/pages/forms/court-order-ma/_steps/AddressStep.tsx
+++ b/src/pages/forms/court-order-ma/_steps/AddressStep.tsx
@@ -65,8 +65,8 @@ export const addressStep: StepConfig = {
           <a href="https://www.masstpc.org/homelessness/">
             Massachusetts Transgender Political Coalition
           </a>
-          . MTPC may be able to provide an address to use for your name change
-          application and help you find housing.
+          . MTPC can provide an address to use for your name change application
+          and connect you with housing resources.
         </Banner>
       )}
       {form.watch("isCurrentlyUnhoused") !== true && (


### PR DESCRIPTION
<img width="2412" height="770" alt="CleanShot 2026-02-02 at 12 49 31@2x" src="https://github.com/user-attachments/assets/40ff4c0d-712c-43af-9f4d-3f731fe672e0" />

Add a new banner to help any unhoused applicants find an address to apply under, and connect with housing resources.