### PR TITLE
Bump IDB version and migrate formFields data to formData

### DIFF
--- a/src/db/init.ts
+++ b/src/db/init.ts
@@ -3,7 +3,7 @@ import { migrations } from "./migrations";
 import type { NamesakeDB, NamesakeDBSchema } from "./types";
 
 export const DB_NAME = "namesake";
-export const DB_VERSION = 2;
+export const DB_VERSION = 3;
 
 export { FORM_DATA_STORE, FORM_PROGRESS_STORE } from "./types";
 

--- a/src/db/migrations/003-fix-form-data-for-safari.ts
+++ b/src/db/migrations/003-fix-form-data-for-safari.ts
@@ -1,0 +1,38 @@
+import type { IDBPDatabase, IDBPTransaction } from "idb";
+import type { FormFieldRecord, Migration } from "../types";
+import { FORM_DATA_STORE } from "../types";
+
+// Safari iOS < 14.5 silently ignores the IDBObjectStore.name setter, so
+// migration 002's rename of formFields → formData was a no-op on those devices.
+// The DB was still bumped to v2, leaving it with formFields + formProgress but
+// no formData, causing all saves to fail with NotFoundError.
+// This migration detects that stuck state and repairs it by manually creating
+// formData, copying records from formFields, then deleting formFields.
+
+interface LegacySchema {
+  formFields: { key: string; value: FormFieldRecord };
+}
+
+export const migration: Migration = async (db, tx) => {
+  const rawDb = db as unknown as IDBPDatabase<LegacySchema>;
+  const rawTx = tx as unknown as IDBPTransaction<
+    LegacySchema,
+    ["formFields"],
+    "versionchange"
+  >;
+
+  if (
+    rawDb.objectStoreNames.contains("formFields") &&
+    !rawDb.objectStoreNames.contains(FORM_DATA_STORE)
+  ) {
+    (db as unknown as IDBPDatabase).createObjectStore(FORM_DATA_STORE, {
+      keyPath: "field",
+    });
+    const records = await rawTx.objectStore("formFields").getAll();
+    const newTx = tx as unknown as IDBPTransaction<any, any, "versionchange">;
+    for (const record of records) {
+      await newTx.objectStore(FORM_DATA_STORE).put(record);
+    }
+    rawDb.deleteObjectStore("formFields");
+  }
+};

--- a/src/db/migrations/__tests__/003-fix-form-data-for-safari.test.ts
+++ b/src/db/migrations/__tests__/003-fix-form-data-for-safari.test.ts
@@ -1,0 +1,67 @@
+import { IDBFactory } from "fake-indexeddb";
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it } from "vitest";
+import { FORM_DATA_STORE, FORM_PROGRESS_STORE } from "../../types";
+import { migration } from "../003-fix-form-data-for-safari";
+import { makeMockDb, runMockMigration, writeMockRecord } from "../test-utils";
+
+const LEGACY_STORE = "formFields";
+
+// Simulates the stuck Safari iOS v2 state: formFields + formProgress, no formData.
+const withStuckSafariV2State = (db: any) => {
+  db.createObjectStore(LEGACY_STORE, { keyPath: "field" });
+  db.createObjectStore(FORM_PROGRESS_STORE, { keyPath: "formSlug" });
+};
+
+beforeEach(() => {
+  global.indexedDB = new IDBFactory();
+});
+
+describe("003: fix formData for Safari iOS", () => {
+  it("creates formData when stuck in Safari state", async () => {
+    const db = await runMockMigration(migration, 3, withStuckSafariV2State);
+    expect(db.objectStoreNames.contains(FORM_DATA_STORE)).toBe(true);
+    db.close();
+  });
+
+  it("removes formFields when stuck in Safari state", async () => {
+    const db = await runMockMigration(migration, 3, withStuckSafariV2State);
+    expect((db as any).objectStoreNames.contains(LEGACY_STORE)).toBe(false);
+    db.close();
+  });
+
+  it("preserves formProgress when stuck in Safari state", async () => {
+    const db = await runMockMigration(migration, 3, withStuckSafariV2State);
+    expect(db.objectStoreNames.contains(FORM_PROGRESS_STORE)).toBe(true);
+    db.close();
+  });
+
+  it("copies formFields records into formData", async () => {
+    const setupDb = await runMockMigration((db) => {
+      (db as any).createObjectStore(LEGACY_STORE, { keyPath: "field" });
+      (db as any).createObjectStore(FORM_PROGRESS_STORE, {
+        keyPath: "formSlug",
+      });
+    }, 2);
+    setupDb.close();
+
+    await writeMockRecord(2, LEGACY_STORE, {
+      field: "firstName",
+      value: "Alice",
+      createdAt: 1000,
+      updatedAt: 2000,
+    });
+
+    const db = await runMockMigration(migration, 3);
+    const record = await db.get(FORM_DATA_STORE, "firstName");
+    expect(record?.value).toBe("Alice");
+    expect(record?.createdAt).toBe(1000);
+    expect(record?.updatedAt).toBe(2000);
+    db.close();
+  });
+
+  it("is idempotent when formData and formProgress already exist", () => {
+    const mockDb = makeMockDb([FORM_DATA_STORE, FORM_PROGRESS_STORE]);
+    expect(() => migration(mockDb, null as any)).not.toThrow();
+  });
+});

--- a/src/db/migrations/__tests__/index.test.ts
+++ b/src/db/migrations/__tests__/index.test.ts
@@ -75,4 +75,24 @@ describe("upgrade paths", () => {
     expect(db.objectStoreNames.contains(FORM_PROGRESS_STORE)).toBe(true);
     expect((db as any).objectStoreNames.contains(LEGACY_STORE)).toBe(false);
   });
+
+  it("v2 stuck Safari state → current: formData created, formFields removed", async () => {
+    // Simulate the Safari iOS bug: DB was upgraded to v2 but the
+    // IDBObjectStore.name setter silently failed, leaving formFields intact.
+    const setupDb = await openDB(DB_NAME, 2, {
+      upgrade(db) {
+        (db as any).createObjectStore(LEGACY_STORE, { keyPath: "field" });
+        (db as any).createObjectStore(FORM_PROGRESS_STORE, {
+          keyPath: "formSlug",
+        });
+      },
+    });
+    setupDb.close();
+
+    const { getDB } = await import("../../init");
+    const db = await getDB();
+    expect(db.objectStoreNames.contains(FORM_DATA_STORE)).toBe(true);
+    expect(db.objectStoreNames.contains(FORM_PROGRESS_STORE)).toBe(true);
+    expect((db as any).objectStoreNames.contains(LEGACY_STORE)).toBe(false);
+  });
 });

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -1,8 +1,10 @@
 import type { Migration } from "../types";
 import { migration as createFormFields } from "./001-create-form-fields";
 import { migration as renameFormFieldsToFormData } from "./002-rename-form-fields-to-form-data";
+import { migration as fixFormDataForSafari } from "./003-fix-form-data-for-safari";
 
 export const migrations: Migration[] = [
   createFormFields,
   renameFormFieldsToFormData,
+  fixFormDataForSafari,
 ];

--- a/src/db/migrations/test-utils.ts
+++ b/src/db/migrations/test-utils.ts
@@ -37,8 +37,8 @@ export async function runMockMigration(
   }
 
   return openDB(DB_NAME, toVersion, {
-    upgrade(db, _oldVersion, _newVersion, tx) {
-      migration(db as any, tx as any);
+    async upgrade(db, _oldVersion, _newVersion, tx) {
+      await migration(db as any, tx as any);
     },
   });
 }

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -30,4 +30,4 @@ export type Migration = (
     Array<keyof NamesakeDBSchema>,
     "versionchange"
   >,
-) => void;
+) => void | Promise<void>;


### PR DESCRIPTION
Followup to #374 to handle the state where the IndexedDB has been upgraded to version 2 but the formFields table has not been renamed to formData.