### PR TITLE
Delete IDB rows when a value is cleared from an input

### DIFF
--- a/src/components/react/forms/MemorableDateField/MemorableDateField.tsx
+++ b/src/components/react/forms/MemorableDateField/MemorableDateField.tsx
@@ -44,7 +44,7 @@ export function MemorableDateField<T extends DateValue>({
               {...field}
               value={dateValue as T}
               onChange={(date) => {
-                onChange(date?.toString());
+                onChange(date ? date.toString() : null);
                 props.onChange?.(date);
               }}
               label={label}

--- a/src/forms/__tests__/useFormData.test.ts
+++ b/src/forms/__tests__/useFormData.test.ts
@@ -6,12 +6,14 @@ import { useFormData } from "../useFormData";
 vi.mock("@/db/database", () => ({
   getFieldsByNames: vi.fn(),
   saveField: vi.fn(),
+  deleteField: vi.fn(),
 }));
 
 describe("useFormData", () => {
   beforeEach(() => {
     vi.mocked(database.getFieldsByNames).mockResolvedValue([]);
     vi.mocked(database.saveField).mockResolvedValue(undefined);
+    vi.mocked(database.deleteField).mockResolvedValue(undefined);
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
@@ -108,7 +110,7 @@ describe("useFormData", () => {
       });
     });
 
-    it("does not save when value is an empty string", async () => {
+    it("deletes a field when its value is cleared to an empty string", async () => {
       const { result } = renderHook(() => useFormData(["oldFirstName"]));
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -118,12 +120,13 @@ describe("useFormData", () => {
         result.current.setValue("oldFirstName", "");
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
+      await waitFor(() => {
+        expect(database.deleteField).toHaveBeenCalledWith("oldFirstName");
+      });
       expect(database.saveField).not.toHaveBeenCalled();
     });
 
-    it("does not save when value is null", async () => {
+    it("deletes a field when its value is set to null", async () => {
       const { result } = renderHook(() => useFormData(["oldFirstName"]));
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -133,9 +136,33 @@ describe("useFormData", () => {
         result.current.setValue("oldFirstName", null);
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
+      await waitFor(() => {
+        expect(database.deleteField).toHaveBeenCalledWith("oldFirstName");
+      });
       expect(database.saveField).not.toHaveBeenCalled();
+    });
+
+    it("logs an error when deleteField throws during auto-save", async () => {
+      vi.mocked(database.deleteField).mockRejectedValue(
+        new Error("Delete failed"),
+      );
+
+      const { result } = renderHook(() => useFormData(["oldFirstName"]));
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      vi.clearAllMocks();
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      await act(async () => {
+        result.current.setValue("oldFirstName", null);
+      });
+
+      await waitFor(() => {
+        expect(console.error).toHaveBeenCalledWith(
+          "Error saving field oldFirstName:",
+          expect.any(Error),
+        );
+      });
     });
 
     it("logs an error when saveField throws during auto-save", async () => {

--- a/src/forms/__tests__/useFormData.test.ts
+++ b/src/forms/__tests__/useFormData.test.ts
@@ -142,6 +142,22 @@ describe("useFormData", () => {
       expect(database.saveField).not.toHaveBeenCalled();
     });
 
+    it("deletes a field when its value is set to an empty array", async () => {
+      const { result } = renderHook(() => useFormData(["pronouns"]));
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      vi.clearAllMocks();
+
+      await act(async () => {
+        result.current.setValue("pronouns", []);
+      });
+
+      await waitFor(() => {
+        expect(database.deleteField).toHaveBeenCalledWith("pronouns");
+      });
+      expect(database.saveField).not.toHaveBeenCalled();
+    });
+
     it("logs an error when deleteField throws during auto-save", async () => {
       vi.mocked(database.deleteField).mockRejectedValue(
         new Error("Delete failed"),

--- a/src/forms/useFormData.ts
+++ b/src/forms/useFormData.ts
@@ -7,7 +7,7 @@ import {
   useForm,
 } from "react-hook-form";
 import type { FieldName } from "@/constants/fields";
-import { getFieldsByNames, saveField } from "@/db/database";
+import { deleteField, getFieldsByNames, saveField } from "@/db/database";
 
 export function useFormData<TFieldValues extends FieldValues = FieldValues>(
   fields: readonly FieldName[],
@@ -52,16 +52,16 @@ export function useFormData<TFieldValues extends FieldValues = FieldValues>(
 
       const fieldValue = value[name];
 
-      if (
-        fieldValue !== "" &&
-        fieldValue !== null &&
-        fieldValue !== undefined
-      ) {
-        try {
+      if (fieldValue === undefined) return;
+
+      try {
+        if (fieldValue === null || fieldValue === "") {
+          await deleteField(name);
+        } else {
           await saveField(name, fieldValue);
-        } catch (error) {
-          console.error(`Error saving field ${name}:`, error);
         }
+      } catch (error) {
+        console.error(`Error saving field ${name}:`, error);
       }
     });
 

--- a/src/forms/useFormData.ts
+++ b/src/forms/useFormData.ts
@@ -55,7 +55,11 @@ export function useFormData<TFieldValues extends FieldValues = FieldValues>(
       if (fieldValue === undefined) return;
 
       try {
-        if (fieldValue === null || fieldValue === "") {
+        if (
+          fieldValue === null ||
+          fieldValue === "" ||
+          (Array.isArray(fieldValue) && fieldValue.length === 0)
+        ) {
           await deleteField(name);
         } else {
           await saveField(name, fieldValue);


### PR DESCRIPTION
When text inputs or other fields were cleared while filling out a form, the row in IndexedDB would be left behind with a single character. Date fields, when cleared, preserved the month and day but set the year to "0001".

This updates the formData handler to properly delete rows from IndexedDB if the value is cleared from the input. This includes empty strings, `null`, dates, and empty arrays.