### PR TITLE
Fix build memory error

### DIFF
--- a/src/components/SupportMap.astro
+++ b/src/components/SupportMap.astro
@@ -210,12 +210,12 @@ function getFillForSupportLevel(supportLevel: string): string {
 </section>
 
 <script>
-  import * as d3 from "d3";
+  import { select, selectAll } from "d3-selection";
 
-  const container = d3.select(".map-container");
+  const container = select(".map-container");
   const svg = container.select("svg");
   const states = svg.selectAll("path.state");
-  const legendItems = d3.selectAll(".legend-item");
+  const legendItems = selectAll(".legend-item");
   const tooltip = container.select(".map-tooltip");
 
   function updatePatternScales() {
@@ -228,7 +228,7 @@ function getFillForSupportLevel(supportLevel: string): string {
 
       svg.selectAll("pattern").attr("patternTransform", `scale(${1 / scale})`);
 
-      d3.selectAll(".legend-pattern rect")
+      selectAll(".legend-pattern rect")
         .attr("width", 18 / scale)
         .attr("height", 18 / scale)
         .attr("transform", `scale(${scale})`);
@@ -279,7 +279,7 @@ function getFillForSupportLevel(supportLevel: string): string {
         textMap[supportLevel as keyof typeof textMap] || "No Support Yet";
 
       states.attr("data-hovered", null);
-      const hoveredState = d3.select(this);
+      const hoveredState = select(this as SVGPathElement);
       hoveredState.attr("data-hovered", "true");
 
       const node = hoveredState.node() as SVGPathElement;
@@ -294,7 +294,7 @@ function getFillForSupportLevel(supportLevel: string): string {
       positionTooltip(event);
     })
     .on("mouseleave", function () {
-      d3.select(this).attr("data-hovered", null);
+      select(this as SVGPathElement).attr("data-hovered", null);
       tooltip.attr("data-visible", null);
     });
 

--- a/src/forms/createFormSubmitHandler.ts
+++ b/src/forms/createFormSubmitHandler.ts
@@ -3,11 +3,10 @@ import type { UseFormReturn } from "react-hook-form";
 import { resolveVisibleFields } from "@/components/react/forms/FormContainer/resolveVisibleFields";
 import type { FormData } from "@/constants/fields";
 import type { FormConfig } from "@/constants/forms";
-import { downloadMergedPdf } from "@/pdfs/utils/downloadMergedPdf";
-import { loadPdfs } from "@/pdfs/utils/loadPdfs";
 
 /**
  * Creates a form submit handler from a form configuration.
+ * PDF lib and utilities are loaded on demand when the user clicks download.
  *
  * @param config - The form configuration
  * @param form - The react-hook-form instance
@@ -26,6 +25,11 @@ export function createFormSubmitHandler<TFormData extends FormData>(
       pdfId: pdf.pdfId,
       include: pdf.include ? pdf.include(formData) : true,
     }));
+
+    const [{ loadPdfs }, { downloadMergedPdf }] = await Promise.all([
+      import("@/pdfs/utils/loadPdfs"),
+      import("@/pdfs/utils/downloadMergedPdf"),
+    ]);
 
     const pdfs = await loadPdfs(pdfConfigs);
     const visibleData = resolveVisibleFields(config.steps, formData);

--- a/src/pdfs/index.ts
+++ b/src/pdfs/index.ts
@@ -1,7 +1,7 @@
 import type { PDFDefinition, PDFId } from "@/constants/pdf";
 
 export async function getPdfDefinition(pdfId: PDFId) {
-  const pdfModules = import.meta.glob("/src/pdfs/*/!(*.test|utils).ts", {
+  const pdfModules = import.meta.glob("/src/pdfs/!(utils)/**/!(*.test).ts", {
     import: "default",
   });
 


### PR DESCRIPTION
- Do not import all of d3
- Lazy-load `pdf-lib` when needed instead of pre-bundling
- Exclude `/utils` folder from `getPdfDefinition`