### PR TITLE
Show donate form in a dialog instead of redirecting

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import { RiHeart3Line } from "@remixicon/react";
-import siteInfo from "@/constants/site-info";
+import { siteInfo } from "@/constants/site-info";
 import Logo from "./Logo.astro";
 import Subscribe from "./Subscribe.astro";
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,5 @@
 ---
-import siteInfo from "@/constants/site-info";
+import { siteInfo } from "@/constants/site-info";
 import Logo from "./Logo.astro";
 
 const { pathname } = Astro.url;

--- a/src/constants/site-info.ts
+++ b/src/constants/site-info.ts
@@ -49,7 +49,7 @@ export type SiteInfo = {
   socialLinks: Record<SocialPlatform, SocialLink>;
 };
 
-const siteInfo: SiteInfo = {
+export const siteInfo: SiteInfo = {
   name: "Namesake",
   fullName: "Namesake Collaborative",
   title: "Your name is yours to change",
@@ -65,7 +65,8 @@ const siteInfo: SiteInfo = {
     blog: "/blog",
     chat: "/chat",
     status: "/status",
-    donate: "https://www.every.org/namesake?suggestedAmounts=20%2C40%2C100%2C250&theme_color=6E56CF&method=card%2Cbank%2Cpaypal%2Cvenmo%2Cpay%2Cdaf&utm_campaign=donate-link#/donate",
+    donate:
+      "https://www.every.org/namesake?suggestedAmounts=20%2C40%2C100%2C250&theme_color=6E56CF&method=card%2Cbank%2Cpaypal%2Cvenmo%2Cpay%2Cdaf&utm_campaign=donate-link#/donate",
   },
   image: {
     src: "/og/social.png",
@@ -116,5 +117,3 @@ const siteInfo: SiteInfo = {
     },
   },
 };
-
-export default siteInfo;

--- a/src/constants/site-info.ts
+++ b/src/constants/site-info.ts
@@ -65,7 +65,7 @@ const siteInfo: SiteInfo = {
     blog: "/blog",
     chat: "/chat",
     status: "/status",
-    donate: "/donate",
+    donate: "https://www.every.org/namesake?suggestedAmounts=20%2C40%2C100%2C250&theme_color=6E56CF&method=card%2Cbank%2Cpaypal%2Cvenmo%2Cpay%2Cdaf&utm_campaign=donate-link#/donate",
   },
   image: {
     src: "/og/social.png",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,7 +3,7 @@ import Footer from "@/components/Footer.astro";
 import Header from "@/components/Header.astro";
 import type { NamesakeColor } from "@/constants/colors";
 import { colors } from "@/constants/colors";
-import siteInfo from "@/constants/site-info";
+import { siteInfo } from "@/constants/site-info";
 import "../styles/base.css";
 import "../styles/reset.css";
 import "../styles/theme.css";

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -74,6 +74,8 @@ const pageTitle = Astro.url.pathname === "/" ? title : `${title} · Namesake`;
       title="Namesake"
       href={new URL("rss.xml", Astro.site)}
     />
+    <script is:inline async defer src="https://embeds.every.org/0.4/button.js"
+    ></script>
   </head>
   <body data-color={color}>
     <Header />

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -1,6 +1,5 @@
 ---
-return Astro.redirect(
-  "https://www.every.org/namesake?suggestedAmounts=20%2C40%2C100%2C250&theme_color=6E56CF&method=card%2Cbank%2Cpaypal%2Cvenmo%2Cpay%2Cdaf&utm_campaign=donate-link#/donate",
-  308,
-);
+import siteInfo from "@/constants/site-info";
+
+return Astro.redirect(siteInfo.urls.donate, 308);
 ---

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -1,5 +1,7 @@
 ---
-import siteInfo from "@/constants/site-info";
+// We have to import siteInfo as _siteInfo to avoid an Astro type bug
+// See https://github.com/withastro/astro/issues/14684
+import { siteInfo as _siteInfo } from "@/constants/site-info";
 
-return Astro.redirect(siteInfo.urls.donate, 308);
+return Astro.redirect(_siteInfo.urls.donate, 308);
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,7 @@ import type { SanityDocument } from "@sanity/client";
 import Partners from "@/components/Partners.astro";
 import SupportMap from "@/components/SupportMap.astro";
 import PortableText from "@/components/text/PortableText.astro";
-import siteInfo from "@/constants/site-info";
+import { siteInfo } from "@/constants/site-info";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import heroIllustration from "@/pages/home/_hero-form.png";
 import { loadQuery } from "@/sanity/lib/loadQuery";


### PR DESCRIPTION
Clicking the donate link in the header or the footer now triggers a dialog with the donation form instead of redirecting to a separate page. This helps preserve site context and is less jarring to visitors. Closes #380 

<img width="2880" height="1508" alt="CleanShot 2026-03-04 at 20 39 20@2x" src="https://github.com/user-attachments/assets/8f74c6bd-4bea-4758-83d1-683fd9557f07" />

The `/donate` url will still redirect to the every.org donation page.