### PR TITLE
Replace deprecated props in react-aria-components

### DIFF
--- a/src/components/react/forms/AddressField/AddressField.tsx
+++ b/src/components/react/forms/AddressField/AddressField.tsx
@@ -97,10 +97,8 @@ export function AddressField({
             label="State"
             placeholder="Select state"
             autoComplete="address-level1"
-            selectedKey={field.value}
-            onSelectionChange={(key) => {
-              field.onChange(key);
-            }}
+            value={field.value}
+            onChange={field.onChange}
             isInvalid={invalid}
             errorMessage={error?.message}
             menuTrigger="focus"

--- a/src/components/react/forms/ComboBoxField/ComboBoxField.tsx
+++ b/src/components/react/forms/ComboBoxField/ComboBoxField.tsx
@@ -38,10 +38,8 @@ export function ComboBoxField({
             {...field}
             label={smartquotes(label)}
             placeholder={placeholder}
-            selectedKey={field.value}
-            onSelectionChange={(key) => {
-              field.onChange(key);
-            }}
+            value={field.value}
+            onChange={field.onChange}
             isInvalid={invalid}
             errorMessage={error?.message}
             {...props}

--- a/src/components/react/forms/LanguageSelectField/LanguageSelectField.tsx
+++ b/src/components/react/forms/LanguageSelectField/LanguageSelectField.tsx
@@ -31,10 +31,8 @@ export function LanguageSelectField({
             label="Language"
             placeholder="Select a language"
             className="w-fit"
-            selectedKey={field.value}
-            onSelectionChange={(key) => {
-              field.onChange(key);
-            }}
+            value={field.value}
+            onChange={field.onChange}
             isInvalid={invalid}
             errorMessage={error?.message}
             {...props}


### PR DESCRIPTION
The `selectedKey` and `onSelectionChange` props were deprecated. Replace with `value` and `onChange`.