### PR TITLE
Add projects to test Firefox and Webkit when running Playwright

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,9 +28,13 @@ permissions:
 
 jobs:
   test:
-    name: End-to-End
+    name: End-to-End (${{ matrix.browser }})
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
 
     steps:
       - name: Checkout code
@@ -49,15 +53,15 @@ jobs:
         run: pnpm i
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium
+        run: pnpm exec playwright install --with-deps ${{ matrix.browser }}
 
       - name: Run Playwright tests
-        run: pnpm test:e2e
+        run: pnpm exec playwright test --reporter=html --project=${{ matrix.browser }}
 
       - name: Upload Playwright results
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.browser }}
           path: playwright-report/
           retention-days: 30

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,6 +17,14 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
   ],
   webServer: {
     command: "pnpm dev",

--- a/src/pages/forms/court-order-ma/_e2e.spec.ts
+++ b/src/pages/forms/court-order-ma/_e2e.spec.ts
@@ -125,16 +125,9 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
       page.getByRole("heading", { name: "What is your date of birth?" }),
     ).toBeVisible();
 
-    await page.getByRole("group", { name: "Date of birth" }).click();
     await page
       .getByRole("spinbutton", { name: "month, Date of birth" })
-      .fill("01");
-    await page
-      .getByRole("spinbutton", { name: "day, Date of birth" })
-      .fill("01");
-    await page
-      .getByRole("spinbutton", { name: "year, Date of birth" })
-      .fill("1970");
+      .pressSequentially("01011970");
 
     await page.getByRole("button", { name: "Continue" }).click();
   });

--- a/src/pages/forms/social-security/_e2e.spec.ts
+++ b/src/pages/forms/social-security/_e2e.spec.ts
@@ -119,16 +119,9 @@ test("Social Security", async ({ page }, testInfo) => {
       page.getByRole("heading", { name: "What is your date of birth?" }),
     ).toBeVisible();
 
-    await page.getByRole("group", { name: "Date of birth" }).click();
     await page
       .getByRole("spinbutton", { name: "month, Date of birth" })
-      .fill("01");
-    await page
-      .getByRole("spinbutton", { name: "day, Date of birth" })
-      .fill("01");
-    await page
-      .getByRole("spinbutton", { name: "year, Date of birth" })
-      .fill("1970");
+      .pressSequentially("01011970");
 
     await page.getByRole("button", { name: "Continue" }).click();
   });


### PR DESCRIPTION
Update Playwright config and GitHub workflow to also test Firefox and Webkit, in addition to Chromium.