### PR TITLE
Cache Playwright browser installs during GitHub Actions runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,13 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v6
+        run: corepack enable
         with:
           node-version: "24.x"
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Typecheck
         run: pnpm tsc -b

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v6
-        run: corepack enable
         with:
           node-version: "24.x"
           cache: "pnpm"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,6 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v6
-        run: corepack enable
         with:
           node-version: "24.x"
           cache: 'pnpm'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
         with:
           run_install: false
 
@@ -62,7 +62,7 @@ jobs:
           ref: main
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
         with:
           run_install: false
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,12 +34,13 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v6
+        run: corepack enable
         with:
           node-version: "24.x"
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Test coverage
         run: npx vitest --coverage.enabled true

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v6
-        run: corepack enable
         with:
           node-version: "24.x"
           cache: "pnpm"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -47,12 +47,13 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v6
+        run: corepack enable
         with:
           node-version: "24.x"
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm i
+        run: pnpm install --frozen-lockfile
 
       - name: Resolve Playwright version
         shell: bash

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,6 +10,7 @@ on:
         "astro.config.ts",
         "playwright.config.ts",
         "package.json",
+        "pnpm-lock.yaml",
       ]
   pull_request:
     branches: [main]
@@ -21,6 +22,7 @@ on:
         "astro.config.ts",
         "playwright.config.ts",
         "package.json",
+        "pnpm-lock.yaml",
       ]
 
 permissions:
@@ -52,8 +54,26 @@ jobs:
       - name: Install dependencies
         run: pnpm i
 
-      - name: Install Playwright browsers
+      - name: Resolve Playwright version
+        shell: bash
+        run: |
+          VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")
+          echo "PLAYWRIGHT_VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Cache Playwright browser binaries
+        uses: actions/cache@v5
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-${{ matrix.browser }}
+
+      - name: Install Playwright browsers and OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps ${{ matrix.browser }}
 
       - name: Run Playwright tests
         run: pnpm exec playwright test --reporter=html --project=${{ matrix.browser }}

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -23,12 +23,13 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v6
+        run: corepack enable
         with:
           node-version: "24.x"
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm i
+        run: pnpm install --frozen-lockfile
 
       - name: Deploy Sanity Studio
         run: pnpm sanity deploy

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -23,7 +23,6 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v6
-        run: corepack enable
         with:
           node-version: "24.x"
           cache: "pnpm"

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -31,7 +31,6 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v6
-        run: corepack enable
         with:
           node-version: "24.x"
           cache: "pnpm"

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -31,12 +31,13 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v6
+        run: corepack enable
         with:
           node-version: "24.x"
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build Storybook
         run: pnpm storybook:build

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typegen": "sanity schema extract --enforce-required-fields && sanity typegen generate"
   },
   "lint-staged": {
-    "*": [
+    "*.{astro,cjs,css,js,json,jsonc,jsx,mjs,ts,tsx}": [
       "biome check --write"
     ]
   },


### PR DESCRIPTION
Cut the time required to (re)install browsers on each new Playwright run.

Downgrade `pnpm/action-setup@v6` to `v5` pending resolution here: https://github.com/pnpm/action-setup/pull/230