### PR TITLE
Update Sanity schema to allow italics in rich text blocks

### DIFF
--- a/src/sanity/schema/blocks/blockquote.ts
+++ b/src/sanity/schema/blocks/blockquote.ts
@@ -18,7 +18,10 @@ export const blockquoteBlock: ObjectDefinition = {
           type: "block",
           styles: [{ title: "Normal", value: "normal" }],
           marks: {
-            decorators: [{ title: "Bold", value: "strong" }],
+            decorators: [
+              { title: "Bold", value: "strong" },
+              { title: "Emphasis", value: "em" },
+            ],
             annotations: [
               defineArrayMember(externalLink),
               defineArrayMember(internalLink),

--- a/src/sanity/schema/blocks/details.ts
+++ b/src/sanity/schema/blocks/details.ts
@@ -21,7 +21,10 @@ export const detailsBlock: ObjectDefinition = {
           type: "block",
           styles: [{ title: "Normal", value: "normal" }],
           marks: {
-            decorators: [{ title: "Bold", value: "strong" }],
+            decorators: [
+              { title: "Bold", value: "strong" },
+              { title: "Emphasis", value: "em" },
+            ],
             annotations: [
               defineArrayMember(externalLink),
               defineArrayMember(internalLink),

--- a/src/sanity/schema/blocks/image.ts
+++ b/src/sanity/schema/blocks/image.ts
@@ -28,7 +28,10 @@ export const imageBlock = {
           type: "block",
           styles: [{ title: "Normal", value: "normal" }],
           marks: {
-            decorators: [{ title: "Bold", value: "strong" }],
+            decorators: [
+              { title: "Bold", value: "strong" },
+              { title: "Emphasis", value: "em" },
+            ],
             annotations: [
               defineArrayMember(externalLink),
               defineArrayMember(internalLink),

--- a/src/sanity/schema/blocks/richText.ts
+++ b/src/sanity/schema/blocks/richText.ts
@@ -18,7 +18,10 @@ export const richTextBlock = {
     { title: "Numbered", value: "number" },
   ],
   marks: {
-    decorators: [{ title: "Bold", value: "strong" }],
+    decorators: [
+      { title: "Bold", value: "strong" },
+      { title: "Emphasis", value: "em" },
+    ],
     annotations: [externalLink, internalLink],
   },
 };

--- a/src/sanity/schema/formType.ts
+++ b/src/sanity/schema/formType.ts
@@ -32,7 +32,10 @@ export const formType = defineType({
           type: "block",
           styles: [{ title: "Normal", value: "normal" }],
           marks: {
-            decorators: [{ title: "Bold", value: "strong" }],
+            decorators: [
+              { title: "Bold", value: "strong" },
+              { title: "Emphasis", value: "em" },
+            ],
             annotations: [
               defineArrayMember(externalLink),
               defineArrayMember(internalLink),


### PR DESCRIPTION
Enable the `em` tag when formatting rich text, now that we have a font which supports italics.