### PR TITLE
Reject unhandled HTTP requests during tests

### DIFF
--- a/src/pages/api/__tests__/feedback.test.ts
+++ b/src/pages/api/__tests__/feedback.test.ts
@@ -177,10 +177,7 @@ describe("POST /api/feedback", () => {
         makeRequest(validBody, { Origin: "http://localhost:4321" }),
       );
 
-      expect(fetch).not.toHaveBeenCalledWith(
-        "https://api.resend.com/emails",
-        expect.anything(),
-      );
+      expect(fetch).not.toHaveBeenCalled();
     });
 
     it("does not send an email when RESEND_API_KEY is absent", async () => {

--- a/src/pages/api/__tests__/feedback.test.ts
+++ b/src/pages/api/__tests__/feedback.test.ts
@@ -99,11 +99,11 @@ describe("POST /api/feedback", () => {
       expect((await callPost(request)).status).toBe(403);
     });
 
-    it("returns 403 for a localhost origin", async () => {
+    it("accepts requests from localhost", async () => {
       const response = await callPost(
         makeRequest(validBody, { Origin: "http://localhost:4321" }),
       );
-      expect(response.status).toBe(403);
+      expect(response.status).toBe(200);
     });
 
     it("returns 403 for a preview deploy origin", async () => {
@@ -137,6 +137,67 @@ describe("POST /api/feedback", () => {
       expect(await response.json()).toMatchObject({
         error: "Too many submissions",
       });
+    });
+  });
+
+  describe("email notifications", () => {
+    beforeEach(() => {
+      env.RESEND_API_KEY = "test-key";
+      vi.spyOn(global, "fetch").mockResolvedValue(
+        new Response(null, { status: 200 }),
+      );
+    });
+
+    it("sends an email for production origin requests", async () => {
+      await callPost(makeRequest(validBody));
+
+      expect(fetch).toHaveBeenCalledWith(
+        "https://api.resend.com/emails",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-key",
+          }),
+          body: expect.stringContaining("court-order-ma"),
+        }),
+      );
+    });
+
+    it("includes the correct recipient and subject in the email", async () => {
+      await callPost(makeRequest(validBody));
+
+      const [, options] = vi.mocked(fetch).mock.calls[0];
+      const body = JSON.parse(options?.body as string);
+      expect(body.to).toBe("hey@namesake.fyi");
+      expect(body.subject).toMatch(/court-order-ma/);
+    });
+
+    it("does not send an email for localhost origin requests", async () => {
+      await callPost(
+        makeRequest(validBody, { Origin: "http://localhost:4321" }),
+      );
+
+      expect(fetch).not.toHaveBeenCalledWith(
+        "https://api.resend.com/emails",
+        expect.anything(),
+      );
+    });
+
+    it("does not send an email when RESEND_API_KEY is absent", async () => {
+      env.RESEND_API_KEY = undefined;
+      await callPost(makeRequest(validBody));
+
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("still returns 200 when the Resend API returns an error", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        new Response("Internal Server Error", { status: 500 }),
+      );
+
+      const response = await callPost(makeRequest(validBody));
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ success: true });
     });
   });
 

--- a/src/pages/api/feedback.ts
+++ b/src/pages/api/feedback.ts
@@ -8,7 +8,8 @@ import {
 } from "../../constants/forms";
 import { isRateLimited } from "../../utils/rateLimitByIp";
 
-const ALLOWED_ORIGINS = ["https://namesake.fyi", "http://localhost:4321"];
+const PRODUCTION_ORIGIN = "https://namesake.fyi";
+const ALLOWED_ORIGINS = [PRODUCTION_ORIGIN, "http://localhost:4321"];
 
 const FeedbackSchema = z.object({
   form_slug: z.enum(FORM_SLUGS),
@@ -87,10 +88,16 @@ export const POST: APIRoute = async ({ request }) => {
     .run();
 
   const resendApiKey = env?.RESEND_API_KEY as string | undefined;
-  const isProductionRequest = origin === "https://namesake.fyi";
-  if (resendApiKey && isProductionRequest) {
+  if (resendApiKey && origin === PRODUCTION_ORIGIN) {
     const sentimentLabel = FORM_FEEDBACK_SENTIMENT[sentiment];
     const location = [city, region, country].filter(Boolean).join(", ");
+
+    const escapeHtml = (text: string) =>
+      text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
 
     try {
       const emailRes = await fetch("https://api.resend.com/emails", {
@@ -103,7 +110,7 @@ export const POST: APIRoute = async ({ request }) => {
           from: "noreply@namesake.fyi",
           to: "hey@namesake.fyi",
           subject: `${sentimentLabel} feedback on ${form_slug}`,
-          html: `<p>A user ${location ? `in <strong>${location}</strong>` : ""} submitted <strong>${sentimentLabel}</strong> feedback on <a href="https://namesake.fyi/forms/${form_slug}">${form_slug}</a>.</p><p>${commentValue ?? "<em>No comment</em>"}</p>`,
+          html: `<p>A user ${location ? `in <strong>${location}</strong>` : ""} submitted <strong>${sentimentLabel}</strong> feedback on <a href="https://namesake.fyi/forms/${form_slug}">${form_slug}</a>.</p><p>${commentValue ? escapeHtml(commentValue) : "<em>No comment</em>"}</p>`,
         }),
       });
       if (!emailRes.ok) {

--- a/src/pages/api/feedback.ts
+++ b/src/pages/api/feedback.ts
@@ -8,7 +8,7 @@ import {
 } from "../../constants/forms";
 import { isRateLimited } from "../../utils/rateLimitByIp";
 
-const ALLOWED_ORIGINS = ["https://namesake.fyi"];
+const ALLOWED_ORIGINS = ["https://namesake.fyi", "http://localhost:4321"];
 
 const FeedbackSchema = z.object({
   form_slug: z.enum(FORM_SLUGS),
@@ -87,7 +87,8 @@ export const POST: APIRoute = async ({ request }) => {
     .run();
 
   const resendApiKey = env?.RESEND_API_KEY as string | undefined;
-  if (resendApiKey) {
+  const isProductionRequest = origin === "https://namesake.fyi";
+  if (resendApiKey && isProductionRequest) {
     const sentimentLabel = FORM_FEEDBACK_SENTIMENT[sentiment];
     const location = [city, region, country].filter(Boolean).join(", ");
 

--- a/src/pages/forms/court-order-ma/_e2e.spec.ts
+++ b/src/pages/forms/court-order-ma/_e2e.spec.ts
@@ -312,11 +312,4 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
       page.getByText(/There are \d+ responses stored on this browser/),
     ).toBeVisible();
   });
-
-  await test.step("Submit feedback", async () => {
-    await page.getByText("It was easy").click();
-    await page.getByRole("textbox", { name: "Feedback" }).fill("Test comment");
-    await page.getByRole("button", { name: "Submit" }).click();
-    await expect(page.getByText("Thank you for your feedback!")).toBeVisible();
-  });
 });

--- a/src/pages/forms/court-order-ma/_e2e.spec.ts
+++ b/src/pages/forms/court-order-ma/_e2e.spec.ts
@@ -315,12 +315,8 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
 
   await test.step("Submit feedback", async () => {
     await page.getByRole("radio", { name: "It was easy" }).click();
-    await page
-      .getByRole("textbox", { name: "Feedback" })
-      .fill("Test comment");
+    await page.getByRole("textbox", { name: "Feedback" }).fill("Test comment");
     await page.getByRole("button", { name: "Submit" }).click();
-    await expect(
-      page.getByText("Thank you for your feedback!"),
-    ).toBeVisible();
+    await expect(page.getByText("Thank you for your feedback!")).toBeVisible();
   });
 });

--- a/src/pages/forms/court-order-ma/_e2e.spec.ts
+++ b/src/pages/forms/court-order-ma/_e2e.spec.ts
@@ -314,7 +314,7 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
   });
 
   await test.step("Submit feedback", async () => {
-    await page.getByRole("radio", { name: "It was easy" }).click();
+    await page.getByText("It was easy").click();
     await page.getByRole("textbox", { name: "Feedback" }).fill("Test comment");
     await page.getByRole("button", { name: "Submit" }).click();
     await expect(page.getByText("Thank you for your feedback!")).toBeVisible();

--- a/src/pages/forms/court-order-ma/_e2e.spec.ts
+++ b/src/pages/forms/court-order-ma/_e2e.spec.ts
@@ -312,4 +312,15 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
       page.getByText(/There are \d+ responses stored on this browser/),
     ).toBeVisible();
   });
+
+  await test.step("Submit feedback", async () => {
+    await page.getByRole("radio", { name: "It was easy" }).click();
+    await page
+      .getByRole("textbox", { name: "Feedback" })
+      .fill("Test comment");
+    await page.getByRole("button", { name: "Submit" }).click();
+    await expect(
+      page.getByText("Thank you for your feedback!"),
+    ).toBeVisible();
+  });
 });

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -54,8 +54,8 @@ beforeEach(() => {
       }
     }
 
-    // For HTTP(S) URLs, use the original fetch
-    return originalFetch(input);
+    // Reject unhandled HTTP requests so tests don't silently hit real servers
+    throw new Error(`Unmocked HTTP request in test: ${url}`);
   });
 });
 


### PR DESCRIPTION
Fixes #543, preventing emails from being sent during unit/e2e tests. Expand test coverage.