### PR TITLE
Remove form revision date

### DIFF
--- a/src/components/forms/FormContainer/FormContainer.tsx
+++ b/src/components/forms/FormContainer/FormContainer.tsx
@@ -31,9 +31,6 @@ export interface FormContainerProps {
   /** Optional banner content (Portable Text) to display on the title step. */
   banner?: PortableTextProps["value"] | null;
 
-  /** The date the form was last updated. */
-  updatedAt?: string;
-
   /** The PDF metadata for forms that will be generated. */
   pdfs?: FormPdfMetadata[];
 
@@ -49,7 +46,6 @@ export function FormContainer({
   title,
   description,
   banner,
-  updatedAt,
   pdfs,
   costs,
   inline = false,
@@ -171,7 +167,6 @@ export function FormContainer({
             title={title}
             description={description}
             pdfs={pdfs ?? []}
-            updatedAt={updatedAt ?? ""}
             totalSteps={totalSteps}
             onStart={onStart}
             headingLevel={inline ? 2 : 1}
@@ -210,7 +205,6 @@ export function FormContainer({
     steps,
     activeStep,
     pdfs,
-    updatedAt,
     title,
     description,
     banner,

--- a/src/components/forms/FormTitleStep/FormTitleStep.css
+++ b/src/components/forms/FormTitleStep/FormTitleStep.css
@@ -86,11 +86,3 @@
     width: 100%;
   }
 }
-
-.form-title-step-date-updated {
-  width: 100%;
-  padding-block-start: var(--space-s);
-  font-size: var(--step--1);
-  text-wrap: pretty;
-  border-top: 1px solid var(--border-color);
-}

--- a/src/components/forms/FormTitleStep/FormTitleStep.tsx
+++ b/src/components/forms/FormTitleStep/FormTitleStep.tsx
@@ -16,11 +16,6 @@ import { Button } from "../../common/Button";
 import { Heading } from "../../common/Content/Content";
 import "./FormTitleStep.css";
 
-const formatter = new Intl.DateTimeFormat("en-US", {
-  dateStyle: "long",
-  timeZone: "UTC",
-});
-
 function FormInfo({ children }: { children: React.ReactNode }) {
   return <ul className="form-info">{children}</ul>;
 }
@@ -54,7 +49,6 @@ export interface FormTitleStepProps {
   onStart: () => void;
   pdfs: FormPdfMetadata[];
   totalSteps: number;
-  updatedAt: string;
   headingLevel?: 1 | 2 | 3;
 }
 
@@ -65,7 +59,6 @@ export function FormTitleStep({
   onStart,
   pdfs,
   totalSteps,
-  updatedAt,
   headingLevel = 1,
 }: FormTitleStepProps) {
   const [device, setDevice] = useState<IDevice | null>(null);
@@ -142,15 +135,6 @@ export function FormTitleStep({
           Start
         </Button>
       </footer>
-      {updatedAt && (
-        <div className="form-title-step-date-updated">
-          Form last revised on{" "}
-          <time dateTime={updatedAt}>
-            {formatter.format(new Date(updatedAt))}
-          </time>
-          .
-        </div>
-      )}
     </section>
   );
 }

--- a/src/components/text/FormEmbed.astro
+++ b/src/components/text/FormEmbed.astro
@@ -27,7 +27,6 @@ const pdfs = await getFormPdfMetadata(slug);
     title={form.title}
     description={form.description}
     banner={form.banner}
-    updatedAt={form._updatedAt}
     pdfs={pdfs}
     costs={form.costs}
     inline

--- a/src/pages/forms/court-order-ma-minor/index.astro
+++ b/src/pages/forms/court-order-ma-minor/index.astro
@@ -24,7 +24,6 @@ const pdfs = await getFormPdfMetadata(formSlug);
     title={form.title}
     description={form.description}
     banner={form?.banner}
-    updatedAt={form?._updatedAt}
     pdfs={pdfs}
     costs={form?.costs}
   />

--- a/src/pages/forms/court-order-ma/index.astro
+++ b/src/pages/forms/court-order-ma/index.astro
@@ -24,7 +24,6 @@ const pdfs = await getFormPdfMetadata(formSlug);
     title={form.title}
     description={form.description}
     banner={form.banner}
-    updatedAt={form._updatedAt}
     pdfs={pdfs}
     costs={form.costs}
   />

--- a/src/pages/forms/social-security/index.astro
+++ b/src/pages/forms/social-security/index.astro
@@ -23,7 +23,6 @@ const pdfs = await getFormPdfMetadata(formSlug);
     slug={formSlug}
     title={form.title}
     description={form.description}
-    updatedAt={form._updatedAt}
     pdfs={pdfs}
   />
 </BaseLayout>


### PR DESCRIPTION
In #556 the main interface for forms was relocated inline to the guides. This meant there were now two separate "last updated" dates displaying on the same page: one for the form, and one for the guide.

In addition, the date for the form was derived from data in Sanity, so if changes had been made to the form components, but no metadata in Sanity had changed for the form, the revision date would be incorrect.

Due to both of these issues, this PR removes the revision date from forms entirely, only showing dates within the guide.