### PR TITLE
Don't attempt to render form if component not found

### DIFF
--- a/src/components/text/FormEmbed.astro
+++ b/src/components/text/FormEmbed.astro
@@ -7,12 +7,11 @@ import { FORM_BY_SLUG_WITH_GUIDE_COSTS_QUERY } from "../../sanity/queries";
 
 const { form: formNode } = Astro.props.node;
 
-if (!formNode?.slug?.current) return;
+const rawSlug = formNode?.slug?.current;
 
-const slugValue = formNode.slug.current;
-if (!(FORM_SLUGS as readonly string[]).includes(slugValue)) return;
+if (!rawSlug || !FORM_SLUGS.includes(rawSlug)) return;
 
-const slug = slugValue as FormSlug;
+const slug = rawSlug as FormSlug;
 
 const form = await sanityClient.fetch(FORM_BY_SLUG_WITH_GUIDE_COSTS_QUERY, {
   slug,

--- a/src/components/text/FormEmbed.astro
+++ b/src/components/text/FormEmbed.astro
@@ -1,7 +1,7 @@
 ---
 import { sanityClient } from "sanity:client";
 import { FormContainer } from "../../components/forms/FormContainer/FormContainer";
-import type { FormSlug } from "../../constants/forms";
+import { FORM_SLUGS, type FormSlug } from "../../constants/forms";
 import { getFormPdfMetadata } from "../../forms/getFormPdfMetadata";
 import { FORM_BY_SLUG_WITH_GUIDE_COSTS_QUERY } from "../../sanity/queries";
 
@@ -9,7 +9,10 @@ const { form: formNode } = Astro.props.node;
 
 if (!formNode?.slug?.current) return;
 
-const slug = formNode.slug.current as FormSlug;
+const slugValue = formNode.slug.current;
+if (!(FORM_SLUGS as readonly string[]).includes(slugValue)) return;
+
+const slug = slugValue as FormSlug;
 
 const form = await sanityClient.fetch(FORM_BY_SLUG_WITH_GUIDE_COSTS_QUERY, {
   slug,


### PR DESCRIPTION
Verify that a slug exists in `FORM_SLUGS` before attempting to render a form via `FormEmbed`.