### PR TITLE
Fix mobile form input overflow

### DIFF
--- a/src/components/common/DatePicker/DatePicker.css
+++ b/src/components/common/DatePicker/DatePicker.css
@@ -1,14 +1,19 @@
 .react-aria-DatePicker {
+  min-width: 0;
+  max-width: 100%;
   color: var(--text-color);
 
   .react-aria-Group {
     display: flex;
     align-items: center;
     width: fit-content;
+    max-width: 100%;
   }
 
   .react-aria-DateInput {
+    box-sizing: border-box;
     width: 16ch;
+    max-width: 100%;
     padding: var(--space-s) var(--space-2xl) var(--space-s) var(--space-s);
   }
 

--- a/src/components/common/InputGroup/InputGroup.css
+++ b/src/components/common/InputGroup/InputGroup.css
@@ -1,8 +1,12 @@
 .input-group {
+  min-width: 0;
+  max-width: 100%;
+
   .react-aria-Group {
     display: flex;
     align-items: center;
     width: fit-content;
+    max-width: 100%;
     overflow: hidden;
     background: var(--field-background);
     border: 1px solid var(--border-color);
@@ -25,6 +29,8 @@
   }
 
   .react-aria-Input {
+    min-width: 0;
+    max-width: 100%;
     padding: var(--space-2xs);
     margin: 0;
     font-size: 1rem;

--- a/src/components/common/NumberField/NumberField.css
+++ b/src/components/common/NumberField/NumberField.css
@@ -1,6 +1,11 @@
 .react-aria-NumberField {
+  min-width: 0;
+  max-width: 100%;
+
   .react-aria-Input {
+    box-sizing: border-box;
     width: 13ch;
+    max-width: 100%;
     padding: var(--space-s) var(--space-m);
     outline: none;
     background: var(--field-background);
@@ -68,6 +73,7 @@
     display: flex;
     align-items: stretch;
     width: fit-content;
+    max-width: 100%;
     border-radius: var(--radius-xs);
 
     &[data-focus-within] {

--- a/src/components/common/TextArea/TextArea.css
+++ b/src/components/common/TextArea/TextArea.css
@@ -2,10 +2,14 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  min-width: 0;
+  max-width: 100%;
   color: var(--text-color);
 
   .react-aria-TextArea {
+    box-sizing: border-box;
     width: 100%;
+    max-width: 100%;
     min-height: var(--space-3xl);
     padding: calc(var(--space-s) + 2px) var(--space-m);
     margin: 0;

--- a/src/components/common/TextField/TextField.css
+++ b/src/components/common/TextField/TextField.css
@@ -1,9 +1,13 @@
 .namesake-text-field {
+  min-width: 0;
+  max-width: 100%;
   color: var(--text-color);
 
   .react-aria-Input,
   .react-aria-TextArea {
+    box-sizing: border-box;
     display: block;
+    max-width: 100%;
     padding: var(--space-s) var(--space-m);
     margin: 0;
     font-size: var(--step-0);

--- a/src/components/forms/AddressField/AddressField.css
+++ b/src/components/forms/AddressField/AddressField.css
@@ -3,4 +3,5 @@
   flex-direction: column;
   gap: var(--space-m);
   width: 100%;
+  min-width: 0;
 }

--- a/src/components/forms/EmailField/EmailField.css
+++ b/src/components/forms/EmailField/EmailField.css
@@ -3,4 +3,5 @@
   flex-direction: column;
   gap: var(--space-m);
   width: 100%;
+  min-width: 0;
 }

--- a/src/components/forms/FormContainer/FormContainer.css
+++ b/src/components/forms/FormContainer/FormContainer.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   gap: var(--space-m);
   width: 100%;
+  min-width: 0;
 
   &:not([data-inline]) {
     min-height: 100dvh;
@@ -12,6 +13,7 @@
 
 .form-container-content {
   width: 100%;
+  min-width: 0;
 
   .form-container:not([data-inline]) & {
     padding-block-end: var(--space-xl);

--- a/src/components/forms/FormStep/FormStep.css
+++ b/src/components/forms/FormStep/FormStep.css
@@ -4,6 +4,8 @@
   gap: var(--space-xl);
   align-items: flex-start;
   justify-content: center;
+  min-width: 0;
+  max-width: 100%;
   border: none;
 
   /* Remove focus outline when programmatically focused */
@@ -15,6 +17,8 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-s);
+    min-width: 0;
+    max-width: 100%;
   }
 }
 
@@ -35,6 +39,7 @@
   flex-direction: column;
   gap: var(--space-l);
   width: 100%;
+  min-width: 0;
 }
 
 .form-subsection {

--- a/src/components/forms/LongTextField/LongTextField.css
+++ b/src/components/forms/LongTextField/LongTextField.css
@@ -3,4 +3,5 @@
   flex-direction: column;
   gap: var(--space-s);
   width: 100%;
+  min-width: 0;
 }

--- a/src/components/forms/NameField/NameField.css
+++ b/src/components/forms/NameField/NameField.css
@@ -3,11 +3,13 @@
   flex-direction: column;
   gap: var(--space-m);
   width: 100%;
+  min-width: 0;
 }
 
 .namesake-name-field-inputs {
   display: flex;
   flex-direction: column;
   gap: var(--space-m);
-  max-width: 30ch;
+  min-width: 0;
+  max-width: min(30ch, 100%);
 }

--- a/src/components/forms/PhoneField/PhoneField.css
+++ b/src/components/forms/PhoneField/PhoneField.css
@@ -3,8 +3,11 @@
   flex-direction: column;
   gap: var(--space-m);
   width: 100%;
+  min-width: 0;
 }
 
 .phone-number-input {
+  box-sizing: border-box;
   width: 20ch;
+  max-width: 100%;
 }

--- a/src/components/forms/ShortTextField/ShortTextField.css
+++ b/src/components/forms/ShortTextField/ShortTextField.css
@@ -3,4 +3,5 @@
   flex-direction: column;
   gap: var(--space-s);
   width: 100%;
+  min-width: 0;
 }


### PR DESCRIPTION
Closes #564

## Summary

- Adds shrink constraints to form containers and field wrappers so wide inputs can fit within narrow viewports.
- Caps reusable input groups and fixed-width field controls at their parent width.
- Adds border-box sizing to padded input surfaces so padding does not force them past their container.

## Notes for review

This includes `box-sizing: border-box` on fixed-`ch` date, number, and phone controls. That keeps the fields inside their containers on narrow screens, but it can make the content area slightly tighter than before, so those controls are worth a visual look.

## Local verification

- `git diff --check`
- `pnpm exec biome check` on the changed CSS files
- `pnpm check`
- `pnpm test:once` - 109 test files / 881 tests passed
- `pnpm build`
- Narrow viewport spot-check on `/forms/court-order-ma` for text, textarea, phone, email, birthplace, and date fields
