### PR TITLE
Update React Aria, fix some broken Storybook stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "idb": "^8.0.3",
     "language-name-map": "^0.3.0",
     "react": "^19.2.6",
-    "react-aria-components": "^1.17.0",
+    "react-aria-components": "^1.18.0",
     "react-dom": "^19.2.6",
     "react-hook-form": "^7.76.1",
     "react-is": "^19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,8 +123,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6
       react-aria-components:
-        specifier: ^1.17.0
-        version: 1.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^1.18.0
+        version: 1.18.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
@@ -2244,11 +2244,14 @@ packages:
   '@internationalized/date@3.12.1':
     resolution: {integrity: sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==}
 
-  '@internationalized/number@3.6.6':
-    resolution: {integrity: sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==}
+  '@internationalized/date@3.12.2':
+    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
 
-  '@internationalized/string@3.2.8':
-    resolution: {integrity: sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==}
+  '@internationalized/number@3.6.7':
+    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
+  '@internationalized/string@3.2.9':
+    resolution: {integrity: sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -2965,8 +2968,8 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/shared@3.34.0':
-    resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
+  '@react-types/shared@3.35.0':
+    resolution: {integrity: sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -6748,14 +6751,14 @@ packages:
   raf@3.4.1:
     resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
 
-  react-aria-components@1.17.0:
-    resolution: {integrity: sha512-0EyisMgvsFJ2aML3crDYv2tW5vT2Ryf8PGzY/g63JjDdCbLshlwazhS8JNtPF1vkTkungJJ6sVJbKyX+YKSoFA==}
+  react-aria-components@1.18.0:
+    resolution: {integrity: sha512-FhRQjuDkH4WhgFv+O2sYTzK3JzdZTGpBeaqfRlfTo+DcSZzD8elJEkytHe7SDpcexVKeire8NVd7OruZHfCVoA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  react-aria@3.48.0:
-    resolution: {integrity: sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==}
+  react-aria@3.49.0:
+    resolution: {integrity: sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -6853,8 +6856,8 @@ packages:
       react: ^18.3 || >=19.0.0-0
       rxjs: ^7
 
-  react-stately@3.46.0:
-    resolution: {integrity: sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==}
+  react-stately@3.47.0:
+    resolution: {integrity: sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -10312,11 +10315,15 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.23
 
-  '@internationalized/number@3.6.6':
+  '@internationalized/date@3.12.2':
     dependencies:
       '@swc/helpers': 0.5.23
 
-  '@internationalized/string@3.2.8':
+  '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/string@3.2.9':
     dependencies:
       '@swc/helpers': 0.5.23
 
@@ -10959,7 +10966,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@react-types/shared@3.34.0(react@19.2.6)':
+  '@react-types/shared@3.35.0(react@19.2.6)':
     dependencies:
       react: 19.2.6
 
@@ -15539,29 +15546,29 @@ snapshots:
     dependencies:
       performance-now: 2.1.0
 
-  react-aria-components@1.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-aria-components@1.18.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@internationalized/date': 3.12.1
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@internationalized/date': 3.12.2
+      '@react-types/shared': 3.35.0(react@19.2.6)
       '@swc/helpers': 0.5.23
       client-only: 0.0.1
       react: 19.2.6
-      react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.46.0(react@19.2.6)
+      react-stately: 3.47.0(react@19.2.6)
 
-  react-aria@3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-aria@3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@internationalized/date': 3.12.1
-      '@internationalized/number': 3.6.6
-      '@internationalized/string': 3.2.8
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.35.0(react@19.2.6)
       '@swc/helpers': 0.5.23
       aria-hidden: 1.2.6
       clsx: 2.1.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.46.0(react@19.2.6)
+      react-stately: 3.47.0(react@19.2.6)
       use-sync-external-store: 1.6.0(react@19.2.6)
 
   react-clientside-effect@1.2.8(react@19.2.6):
@@ -15656,12 +15663,12 @@ snapshots:
       rxjs: 7.8.2
       use-effect-event: 2.0.3(react@19.2.6)
 
-  react-stately@3.46.0(react@19.2.6):
+  react-stately@3.47.0(react@19.2.6):
     dependencies:
-      '@internationalized/date': 3.12.1
-      '@internationalized/number': 3.6.6
-      '@internationalized/string': 3.2.8
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.35.0(react@19.2.6)
       '@swc/helpers': 0.5.23
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)

--- a/src/components/common/Checkbox/Checkbox.css
+++ b/src/components/common/Checkbox/Checkbox.css
@@ -45,7 +45,7 @@
     stroke-dasharray: 22px;
     stroke-dashoffset: 66;
     transform: translateY(-0.5px) translateX(1px);
-    transition: all 200ms ease-out;
+    transition: stroke-dashoffset 200ms ease-out;
   }
 
   &[data-focus-visible] .checkbox {

--- a/src/components/common/Checkbox/Checkbox.css
+++ b/src/components/common/Checkbox/Checkbox.css
@@ -1,3 +1,17 @@
+.namesake-checkbox-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+
+  [slot="description"] {
+    font-size: var(--step--2);
+  }
+
+  &[data-disabled] [slot="description"] {
+    opacity: 0.3;
+  }
+}
+
 .namesake-checkbox {
   --selected-color: var(--highlight-background);
   --selected-color-pressed: var(--highlight-background);

--- a/src/components/common/Checkbox/Checkbox.tsx
+++ b/src/components/common/Checkbox/Checkbox.tsx
@@ -1,6 +1,8 @@
 import {
-  Checkbox as AriaCheckbox,
-  type CheckboxProps as AriaCheckboxProps,
+  CheckboxButton,
+  CheckboxField,
+  type CheckboxFieldProps,
+  Text,
   type ValidationResult,
 } from "react-aria-components";
 import { FieldError } from "../Form";
@@ -9,36 +11,44 @@ import "./Checkbox.css";
 import clsx from "clsx";
 import { smartquotes } from "../../../utils/smartquotes";
 
-export interface CheckboxProps extends AriaCheckboxProps {
+export interface CheckboxProps extends CheckboxFieldProps {
   label?: string;
+  description?: string;
   errorMessage?: string | ((validation: ValidationResult) => string);
 }
 
 export function Checkbox({
   children,
   label,
+  description,
   className,
   errorMessage,
   ...props
 }: CheckboxProps) {
   return (
-    <AriaCheckbox className={clsx("namesake-checkbox", className)} {...props}>
-      {({ isIndeterminate }) => (
-        <>
-          <div className="checkbox">
-            <svg viewBox="0 0 18 18" aria-hidden="true">
-              {isIndeterminate ? (
-                <rect x={1} y={7.5} width={15} height={2} />
-              ) : (
-                <polyline points="1 9 7 14 15 4" />
-              )}
-            </svg>
-          </div>
-          {label && smartquotes(label)}
-          {children}
-          {errorMessage && <FieldError>{errorMessage}</FieldError>}
-        </>
-      )}
-    </AriaCheckbox>
+    <CheckboxField
+      className={clsx("namesake-checkbox-field", className)}
+      {...props}
+    >
+      <CheckboxButton className="namesake-checkbox">
+        {({ isIndeterminate }) => (
+          <>
+            <div className="checkbox">
+              <svg viewBox="0 0 18 18" aria-hidden="true">
+                {isIndeterminate ? (
+                  <rect x={1} y={7.5} width={15} height={2} />
+                ) : (
+                  <polyline points="1 9 7 14 15 4" />
+                )}
+              </svg>
+            </div>
+            {label && smartquotes(label)}
+            {children}
+          </>
+        )}
+      </CheckboxButton>
+      {description && <Text slot="description">{description}</Text>}
+      {errorMessage && <FieldError>{errorMessage}</FieldError>}
+    </CheckboxField>
   );
 }

--- a/src/components/common/RadioGroup/RadioGroup.css
+++ b/src/components/common/RadioGroup/RadioGroup.css
@@ -10,7 +10,22 @@
   }
 }
 
+.namesake-radio-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+
+  [slot="description"] {
+    font-size: var(--step--2);
+  }
+
+  &[data-disabled] [slot="description"] {
+    opacity: 0.3;
+  }
+}
+
 .namesake-radio {
+  /* This is needed so the HiddenInput is positioned correctly */
   position: relative;
   display: flex;
   gap: var(--space-s);

--- a/src/components/common/RadioGroup/RadioGroup.tsx
+++ b/src/components/common/RadioGroup/RadioGroup.tsx
@@ -1,8 +1,9 @@
 import {
-  Radio as AriaRadio,
   RadioGroup as AriaRadioGroup,
   type RadioGroupProps as AriaRadioGroupProps,
-  type RadioProps as AriaRadioProps,
+  RadioButton,
+  RadioField,
+  type RadioFieldProps,
   type ValidationResult,
 } from "react-aria-components";
 import { Text } from "../Content";
@@ -38,8 +39,20 @@ export function RadioGroup({
   );
 }
 
-export interface RadioProps extends AriaRadioProps {}
+export interface RadioProps extends RadioFieldProps {
+  description?: string;
+}
 
-export function Radio({ className, ...props }: RadioProps) {
-  return <AriaRadio {...props} className={clsx("namesake-radio", className)} />;
+export function Radio({
+  className,
+  description,
+  children,
+  ...props
+}: RadioProps) {
+  return (
+    <RadioField className={clsx("namesake-radio-field", className)} {...props}>
+      <RadioButton className="namesake-radio">{children}</RadioButton>
+      {description && <Text slot="description">{description}</Text>}
+    </RadioField>
+  );
 }

--- a/src/components/common/Switch/Switch.css
+++ b/src/components/common/Switch/Switch.css
@@ -1,4 +1,15 @@
-.react-aria-Switch {
+.react-aria-SwitchField {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+
+  &[data-disabled] [slot="description"] {
+    opacity: 0.3;
+  }
+}
+
+.react-aria-SwitchButton {
+  /* This is needed so the HiddenInput is positioned correctly */
   position: relative;
   display: flex;
   gap: var(--space-s);

--- a/src/components/common/Switch/Switch.tsx
+++ b/src/components/common/Switch/Switch.tsx
@@ -1,19 +1,34 @@
 import {
-  Switch as AriaSwitch,
-  type SwitchProps as AriaSwitchProps,
+  SwitchButton,
+  SwitchField,
+  type SwitchFieldProps,
+  type ValidationResult,
 } from "react-aria-components";
+import { Text } from "../Content";
+import { FieldError } from "../Form";
 
 import "./Switch.css";
 
-export interface SwitchProps extends Omit<AriaSwitchProps, "children"> {
+export interface SwitchProps extends Omit<SwitchFieldProps, "children"> {
   children: React.ReactNode;
+  description?: string;
+  errorMessage?: string | ((validation: ValidationResult) => string);
 }
 
-export function Switch({ children, ...props }: SwitchProps) {
+export function Switch({
+  children,
+  description,
+  errorMessage,
+  ...props
+}: SwitchProps) {
   return (
-    <AriaSwitch {...props}>
-      <div className="indicator" />
-      {children}
-    </AriaSwitch>
+    <SwitchField {...props}>
+      <SwitchButton>
+        <div className="indicator" />
+        {children}
+      </SwitchButton>
+      {description && <Text slot="description">{description}</Text>}
+      {errorMessage && <FieldError>{errorMessage}</FieldError>}
+    </SwitchField>
   );
 }

--- a/src/components/forms/CheckboxField/CheckboxField.test.tsx
+++ b/src/components/forms/CheckboxField/CheckboxField.test.tsx
@@ -23,14 +23,10 @@ describe("CheckboxField", () => {
       />,
     );
 
-    const checkboxLabel = screen.getByText(
-      "I would like my documents returned",
-    );
-    await userEvent.click(checkboxLabel);
-
     const checkbox = screen.getByRole("checkbox", {
       name: "I would like my documents returned",
     }) as HTMLInputElement;
+    await userEvent.click(checkbox);
     expect(checkbox.checked).toBe(true);
   });
 

--- a/src/components/forms/CheckboxGroupField/CheckboxGroupField.test.tsx
+++ b/src/components/forms/CheckboxGroupField/CheckboxGroupField.test.tsx
@@ -49,12 +49,10 @@ describe("CheckboxGroupField", () => {
       />,
     );
 
-    const secondOption = screen.getByText("Option 2");
-    await userEvent.click(secondOption);
-
     const selectedCheckbox = screen.getByRole("checkbox", {
       name: "Option 2",
     }) as HTMLInputElement;
+    await userEvent.click(selectedCheckbox);
     expect(selectedCheckbox.checked).toBe(true);
   });
 
@@ -98,7 +96,9 @@ describe("CheckboxGroupField", () => {
     );
 
     // Select prefer not to answer
-    const preferNotToAnswer = screen.getByText("Prefer not to answer");
+    const preferNotToAnswer = screen.getByRole("checkbox", {
+      name: "Prefer not to answer",
+    });
     await userEvent.click(preferNotToAnswer);
 
     // Check that all other options are disabled
@@ -117,7 +117,9 @@ describe("CheckboxGroupField", () => {
     expect(preferNotToAnswerCheckbox.checked).toBe(true);
 
     // Uncheck prefer not to answer
-    await userEvent.click(preferNotToAnswer);
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "Prefer not to answer" }),
+    );
 
     // Verify all options are enabled
     for (const option of mockOptions) {

--- a/src/components/forms/FormReviewStep/FormReviewStep.stories.tsx
+++ b/src/components/forms/FormReviewStep/FormReviewStep.stories.tsx
@@ -1,6 +1,22 @@
 import type { Meta } from "@storybook/react-vite";
-import { FormProvider, useForm } from "react-hook-form";
+import type { Step } from "../../../forms/types";
+import { FormStepContext } from "../FormContainer/FormStepContext";
 import { FormReviewStep, type FormReviewStepProps } from "./FormReviewStep";
+
+const mockSteps: Step[] = [
+  {
+    id: "personal-info",
+    title: "Personal Information",
+    fields: ["oldFirstName", "oldLastName"],
+    component: () => null,
+  },
+  {
+    id: "contact",
+    title: "Contact Details",
+    fields: ["email"],
+    component: () => null,
+  },
+];
 
 const meta: Meta<typeof FormReviewStep> = {
   component: FormReviewStep,
@@ -8,16 +24,26 @@ const meta: Meta<typeof FormReviewStep> = {
     layout: "padded",
   },
   decorators: [
-    (Story) => {
-      const form = useForm();
-      return (
-        <FormProvider {...form}>
-          <form onSubmit={(e) => e.preventDefault()}>
-            <Story />
-          </form>
-        </FormProvider>
-      );
-    },
+    (Story) => (
+      <FormStepContext.Provider
+        value={{
+          onNext: () => console.log("Next clicked"),
+          onBack: () => console.log("Back clicked"),
+          formTitle: "Massachusetts Court Order",
+          currentStepIndex: 0,
+          totalSteps: 3,
+          phase: "review",
+          onSubmit: (e) => {
+            e.preventDefault();
+            console.log("Submit clicked");
+          },
+          onEditStep: () => {},
+          submitError: null,
+        }}
+      >
+        <Story />
+      </FormStepContext.Provider>
+    ),
   ],
 };
 
@@ -27,23 +53,34 @@ export const Default = (args: FormReviewStepProps) => (
   <FormReviewStep {...args} />
 );
 
-Default.args = {};
+Default.args = {
+  steps: mockSteps,
+};
 
-export const WithCustomTitle = (args: FormReviewStepProps) => (
+export const WithSubmitError = (args: FormReviewStepProps) => (
   <FormReviewStep {...args} />
 );
 
-WithCustomTitle.args = {
-  title: "Confirm details",
-  description:
-    "Please double-check all information before submitting. You won't be able to edit these details after submission.",
+WithSubmitError.args = {
+  steps: mockSteps,
 };
 
-export const WithoutDescription = (args: FormReviewStepProps) => (
-  <FormReviewStep {...args} />
-);
-
-WithoutDescription.args = {
-  title: "Review your information",
-  description: undefined,
-};
+WithSubmitError.decorators = [
+  (Story: React.ComponentType) => (
+    <FormStepContext.Provider
+      value={{
+        onNext: () => {},
+        onBack: () => {},
+        formTitle: "Massachusetts Court Order",
+        currentStepIndex: 0,
+        totalSteps: 3,
+        phase: "review",
+        onSubmit: (e) => e.preventDefault(),
+        onEditStep: () => {},
+        submitError: "Something went wrong. Please try again.",
+      }}
+    >
+      <Story />
+    </FormStepContext.Provider>
+  ),
+];

--- a/src/components/forms/FormReviewStep/FormReviewStep.test.tsx
+++ b/src/components/forms/FormReviewStep/FormReviewStep.test.tsx
@@ -44,7 +44,7 @@ describe("FormReviewStep", () => {
     expect(screen.getByText("Review your information")).toBeInTheDocument();
   });
 
-  it("renders with default description", () => {
+  it("renders description", () => {
     render(<FormReviewStep steps={[]} />, { wrapper: TestWrapper });
 
     expect(
@@ -52,43 +52,6 @@ describe("FormReviewStep", () => {
         /Please review your answers before submitting. Once submitted, completed forms will download automatically./i,
       ),
     ).toBeInTheDocument();
-  });
-
-  it("renders with custom title", () => {
-    render(<FormReviewStep title="Confirm Your Details" steps={[]} />, {
-      wrapper: TestWrapper,
-    });
-
-    expect(screen.getByText("Confirm Your Details")).toBeInTheDocument();
-  });
-
-  it("renders with custom description", () => {
-    render(
-      <FormReviewStep
-        steps={[]}
-        title="Review"
-        description="Please double-check everything."
-      />,
-      { wrapper: TestWrapper },
-    );
-
-    expect(
-      screen.getByText("Please double-check everything."),
-    ).toBeInTheDocument();
-  });
-
-  it("does not render description when not provided", () => {
-    render(
-      <FormReviewStep title="Review" description={undefined} steps={[]} />,
-      {
-        wrapper: TestWrapper,
-      },
-    );
-
-    expect(screen.getByText("Review")).toBeInTheDocument();
-
-    const description = document.querySelector(".form-review-step-description");
-    expect(description).not.toBeInTheDocument();
   });
 
   it("renders submit button", () => {

--- a/src/components/forms/FormReviewStep/FormReviewStep.tsx
+++ b/src/components/forms/FormReviewStep/FormReviewStep.tsx
@@ -9,27 +9,12 @@ import { FormReviewTable } from "../FormReviewTable";
 
 export interface FormReviewStepProps {
   /**
-   * The title of the review screen.
-   * @default "Review your information"
-   */
-  title?: string;
-
-  /**
-   * Optional description for the review screen.
-   */
-  description?: string;
-
-  /**
    * The step configurations to display in the review table.
    */
   steps: readonly Step[];
 }
 
-export function FormReviewStep({
-  title = "Review your information",
-  description = "Please review your answers before submitting. Once submitted, completed forms will download automatically.",
-  steps,
-}: FormReviewStepProps) {
+export function FormReviewStep({ steps }: FormReviewStepProps) {
   const { onSubmit, phase, submitError } = useFormStep();
   const isSubmitting = phase === "submitting";
 
@@ -45,10 +30,13 @@ export function FormReviewStep({
       aria-busy={isSubmitting}
     >
       <header className="form-review-step-header">
-        <Heading className="form-review-step-title">{title}</Heading>
-        {description && (
-          <p className="form-review-description">{description}</p>
-        )}
+        <Heading className="form-review-step-title">
+          Review your information
+        </Heading>
+        <p className="form-review-description">
+          Please review your answers before submitting. Once submitted,
+          completed forms will download automatically.
+        </p>
       </header>
       <div
         className="form-review-step-content"

--- a/src/components/forms/FormStep/FormStep.css
+++ b/src/components/forms/FormStep/FormStep.css
@@ -46,9 +46,9 @@
   justify-content: center;
   width: 100%;
   min-width: 0;
-  padding-inline-start: var(--space-xl);
+  padding-inline-start: var(--space-l);
   border: none;
-  border-left: 3px solid var(--border-color);
+  border-left: 4px solid var(--border-color);
 }
 
 .form-subsection h2 {

--- a/src/components/forms/FormStep/FormStep.stories.tsx
+++ b/src/components/forms/FormStep/FormStep.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta } from "@storybook/react-vite";
+import { FormProvider, useForm } from "react-hook-form";
 import { FormStepContext } from "../FormContainer/FormStepContext";
 import { FormStep, type FormStepProps } from "./FormStep";
 
@@ -8,26 +9,31 @@ const meta: Meta<typeof FormStep> = {
     layout: "padded",
   },
   decorators: [
-    (Story) => (
-      <FormStepContext.Provider
-        value={{
-          onNext: () => console.log("Next clicked"),
-          onBack: () => console.log("Back clicked"),
-          formTitle: "Massachusetts Court Order",
-          currentStepIndex: 2, // Step 2 of actual steps
-          totalSteps: 5, // 5 actual steps
-          phase: "filling",
-          onSubmit: (e) => {
-            e.preventDefault();
-            console.log("Submit clicked");
-          },
-          onEditStep: () => {},
-          submitError: null,
-        }}
-      >
-        <Story />
-      </FormStepContext.Provider>
-    ),
+    (Story) => {
+      const form = useForm();
+      return (
+        <FormProvider {...form}>
+          <FormStepContext.Provider
+            value={{
+              onNext: () => console.log("Next clicked"),
+              onBack: () => console.log("Back clicked"),
+              formTitle: "Massachusetts Court Order",
+              currentStepIndex: 2,
+              totalSteps: 5,
+              phase: "filling",
+              onSubmit: (e) => {
+                e.preventDefault();
+                console.log("Submit clicked");
+              },
+              onEditStep: () => {},
+              submitError: null,
+            }}
+          >
+            <Story />
+          </FormStepContext.Provider>
+        </FormProvider>
+      );
+    },
   ],
 };
 
@@ -36,14 +42,24 @@ export default meta;
 export const Example = (args: FormStepProps) => <FormStep {...args} />;
 
 Example.args = {
-  title: "What is your current legal name?",
+  stepConfig: {
+    id: "legal-name",
+    title: "What is your current legal name?",
+    fields: ["oldFirstName", "oldLastName"],
+    component: () => null,
+  },
   children: <div>Children</div>,
 };
 
 export const WithDescription = (args: FormStepProps) => <FormStep {...args} />;
 
 WithDescription.args = {
-  title: "What is your current legal name?",
-  description: "Type your name exactly as it appears on your ID.",
+  stepConfig: {
+    id: "legal-name",
+    title: "What is your current legal name?",
+    description: "Type your name exactly as it appears on your ID.",
+    fields: ["oldFirstName", "oldLastName"],
+    component: () => null,
+  },
   children: <div>Children</div>,
 };

--- a/src/components/forms/FormTitleStep/FormTitleStep.stories.tsx
+++ b/src/components/forms/FormTitleStep/FormTitleStep.stories.tsx
@@ -33,12 +33,27 @@ const meta: Meta<typeof FormTitleStep> = {
 
 export default meta;
 
+const sharedArgs = {
+  title: "Massachusetts Name Change Petition",
+  description:
+    "This guided form will help you complete your name change paperwork.",
+  onStart: () => console.log("Start clicked"),
+  pdfs: [
+    {
+      pdfId: "cjp27-petition-to-change-name-of-adult" as const,
+      title: "Petition to Change Name of Adult",
+      code: "CJP-27",
+    },
+  ],
+  totalSteps: 5,
+};
+
 export const Example = (args: FormTitleStepProps) => (
   <FormTitleStep {...args} />
 );
 
 Example.args = {
-  onStart: () => console.log("Start clicked"),
+  ...sharedArgs,
 };
 
 export const WithChildren = (args: FormTitleStepProps) => (
@@ -46,7 +61,7 @@ export const WithChildren = (args: FormTitleStepProps) => (
 );
 
 WithChildren.args = {
-  onStart: () => console.log("Start clicked"),
+  ...sharedArgs,
   children: (
     <div>
       <p>


### PR DESCRIPTION
[React Aria v1.18.0](https://react-aria.adobe.com/releases/v1-18-0) updates the API for Checkbox, Radio, and Switch to allow setting description and error messages at the component-level. Update components to match.

Remove the `title` and `description` props from `FormReviewStep` since they are constant.