### PR TITLE
Add canonical URLs to all PDF definitions

### DIFF
--- a/pdf-manager/lib/catalog.ts
+++ b/pdf-manager/lib/catalog.ts
@@ -10,6 +10,7 @@ interface PdfMeta {
   title: string;
   code: string;
   jurisdiction: string;
+  canonicalUrl: string;
 }
 
 export interface PdfEntry {
@@ -17,6 +18,7 @@ export interface PdfEntry {
   jurisdiction: string;
   title: string;
   code: string;
+  canonicalUrl: string;
   fieldCount: number;
   pdfPath: string;
   pdfDir: string;
@@ -31,6 +33,7 @@ function parsePdfMetadata(pdfDir: string): PdfMeta | null {
     title: content.match(/\btitle:\s*"([^"]+)"/)?.[1] ?? "",
     code: content.match(/\bcode:\s*"([^"]+)"/)?.[1] ?? "",
     jurisdiction: content.match(/\bjurisdiction:\s*"([^"]+)"/)?.[1] ?? "",
+    canonicalUrl: content.match(/\bcanonicalUrl:\s*"([^"]+)"/)?.[1] ?? "",
   };
 }
 
@@ -63,6 +66,7 @@ export function listAllPdfs(): PdfEntry[] {
         jurisdiction: meta.jurisdiction || entry.name.toUpperCase(),
         title: meta.title,
         code: meta.code,
+        canonicalUrl: meta.canonicalUrl,
         fieldCount: countSchemaFields(pdfDir),
         pdfPath: join(pdfDir, pdfFile),
         pdfDir,

--- a/pdf-manager/lib/define.ts
+++ b/pdf-manager/lib/define.ts
@@ -26,6 +26,7 @@ interface DefinitionParams {
   title: string;
   code: string;
   jurisdiction: string;
+  canonicalUrl: string;
   pdfFields: PdfFieldInfo[];
 }
 
@@ -35,6 +36,7 @@ function generateDefinition({
   title,
   code,
   jurisdiction,
+  canonicalUrl,
   pdfFields,
 }: DefinitionParams): string {
   const props = [
@@ -44,6 +46,7 @@ function generateDefinition({
     ...(jurisdiction && jurisdiction !== "federal"
       ? [`jurisdiction: "${jurisdiction}",`]
       : []),
+    `canonicalUrl: "${canonicalUrl}",`,
     "pdfPath: pdf,",
   ];
   const fieldLines = pdfFields.map((f) => `  ${escapeKey(f.name)}: undefined,`);
@@ -164,6 +167,7 @@ export interface WriteDefinitionFilesParams {
   title: string;
   code: string;
   jurisdiction: string;
+  canonicalUrl: string;
   pdfDir: string;
   pdfDestPath: string;
   indexPath: string;
@@ -178,6 +182,7 @@ export function writeDefinitionFiles({
   title,
   code,
   jurisdiction,
+  canonicalUrl,
   pdfDir,
   pdfDestPath,
   indexPath,
@@ -193,6 +198,7 @@ export function writeDefinitionFiles({
     title,
     code,
     jurisdiction,
+    canonicalUrl,
     pdfFields,
   });
   writeFileSync(indexPath, `${definition}\n`);

--- a/pdf-manager/lib/handlers.ts
+++ b/pdf-manager/lib/handlers.ts
@@ -15,13 +15,16 @@ import { loadSchemaFields, suggestName } from "./suggest.ts";
 
 export async function handleListPdfs(c: Context) {
   return c.json(
-    listAllPdfs().map(({ id, title, code, jurisdiction, fieldCount }) => ({
-      id,
-      title,
-      code,
-      jurisdiction,
-      fieldCount,
-    })),
+    listAllPdfs().map(
+      ({ id, title, code, jurisdiction, canonicalUrl, fieldCount }) => ({
+        id,
+        title,
+        code,
+        jurisdiction,
+        canonicalUrl,
+        fieldCount,
+      }),
+    ),
   );
 }
 
@@ -78,16 +81,20 @@ export async function handleSaveFields(c: Context) {
 }
 
 export async function handleAddPdf(c: Context) {
-  const { title, code, jurisdiction, pdfBase64 } = await c.req.json<{
-    title?: string;
-    code?: string;
-    jurisdiction?: string;
-    pdfBase64?: string;
-  }>();
+  const { title, code, jurisdiction, canonicalUrl, pdfBase64 } =
+    await c.req.json<{
+      title?: string;
+      code?: string;
+      jurisdiction?: string;
+      canonicalUrl?: string;
+      pdfBase64?: string;
+    }>();
 
-  if (!title || !jurisdiction || !pdfBase64) {
+  if (!title || !jurisdiction || !canonicalUrl || !pdfBase64) {
     return c.json(
-      { error: "title, jurisdiction, and pdfBase64 are required" },
+      {
+        error: "title, jurisdiction, canonicalUrl, and pdfBase64 are required",
+      },
       400,
     );
   }
@@ -113,6 +120,7 @@ export async function handleAddPdf(c: Context) {
     title,
     code: code ?? "",
     jurisdiction,
+    canonicalUrl,
     pdfDir,
     pdfDestPath,
     indexPath,

--- a/pdf-manager/src/components/AddPdfModal.tsx
+++ b/pdf-manager/src/components/AddPdfModal.tsx
@@ -44,6 +44,7 @@ export function AddPdfModal({ isOpen, onClose, onSuccess }: AddPdfModalProps) {
     const title = data.get("title") as string;
     const code = data.get("code") as string;
     const jurisdiction = data.get("jurisdiction") as string;
+    const canonicalUrl = data.get("canonicalUrl") as string;
 
     setSubmitting(true);
     setError(null);
@@ -52,7 +53,13 @@ export function AddPdfModal({ isOpen, onClose, onSuccess }: AddPdfModalProps) {
       const res = await fetch("/api/pdfs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title, code, jurisdiction, pdfBase64 }),
+        body: JSON.stringify({
+          title,
+          code,
+          jurisdiction,
+          canonicalUrl,
+          pdfBase64,
+        }),
       });
       const result = await res.json<AddPdfResult>();
       if (!res.ok) throw new Error(result.error ?? "Failed to add PDF");
@@ -108,6 +115,11 @@ export function AddPdfModal({ isOpen, onClose, onSuccess }: AddPdfModalProps) {
             <TextField className="form-field" name="code">
               <Label className="form-label">Form code (optional)</Label>
               <Input className="form-input" />
+            </TextField>
+
+            <TextField className="form-field" isRequired name="canonicalUrl">
+              <Label className="form-label">Canonical URL</Label>
+              <Input className="form-input" type="url" />
             </TextField>
 
             <div className="form-field">

--- a/pdf-manager/src/components/PdfEditor.tsx
+++ b/pdf-manager/src/components/PdfEditor.tsx
@@ -220,23 +220,9 @@ export function PdfEditor({ pdfId, onFieldsChanged }: PdfEditorProps) {
               target="_blank"
               rel="noopener noreferrer"
               className="meta-canonical-link"
-              aria-label="Open canonical PDF"
+              title={meta.canonicalUrl}
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="12"
-                height="12"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <title>Link</title>
-                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-              </svg>
+              {new URL(meta.canonicalUrl).hostname}
             </a>
           )}
         </div>

--- a/pdf-manager/src/components/PdfEditor.tsx
+++ b/pdf-manager/src/components/PdfEditor.tsx
@@ -214,6 +214,31 @@ export function PdfEditor({ pdfId, onFieldsChanged }: PdfEditorProps) {
           {meta?.jurisdiction && (
             <span className="meta-jurisdiction">{meta.jurisdiction}</span>
           )}
+          {meta?.canonicalUrl && (
+            <a
+              href={meta.canonicalUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="meta-canonical-link"
+              aria-label="Open canonical PDF"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <title>Link</title>
+                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+              </svg>
+            </a>
+          )}
         </div>
         <div className="editor-actions">
           {uploadError && (

--- a/pdf-manager/src/styles.css
+++ b/pdf-manager/src/styles.css
@@ -190,15 +190,14 @@ body {
 }
 
 .meta-canonical-link {
-  display: flex;
   flex-shrink: 0;
-  align-items: center;
   color: var(--text-muted);
   text-decoration: none;
-}
 
-.meta-canonical-link:hover {
-  color: var(--text);
+  &:hover {
+    color: var(--text);
+    text-decoration: underline;
+  }
 }
 
 .editor-actions {

--- a/pdf-manager/src/styles.css
+++ b/pdf-manager/src/styles.css
@@ -189,6 +189,18 @@ body {
   color: var(--text-muted);
 }
 
+.meta-canonical-link {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.meta-canonical-link:hover {
+  color: var(--text);
+}
+
 .editor-actions {
   display: flex;
   flex-shrink: 0;

--- a/pdf-manager/src/types.ts
+++ b/pdf-manager/src/types.ts
@@ -9,6 +9,7 @@ export interface PdfMeta {
   title: string;
   code: string;
   jurisdiction: string;
+  canonicalUrl: string;
   fieldCount: number;
 }
 

--- a/src/constants/pdf.ts
+++ b/src/constants/pdf.ts
@@ -43,6 +43,11 @@ export interface PDFDefinition<TPdfFieldName extends string = string> {
   jurisdiction?: Jurisdiction;
 
   /**
+   * The canonical URL of the original form. This should be a link to a .gov website or other official source.
+   */
+  canonicalUrl: string;
+
+  /**
    * The path to the PDF file, imported as a module.
    */
   pdfPath: string;

--- a/src/pdfs/federal/ss5-application-for-social-security-card/index.ts
+++ b/src/pdfs/federal/ss5-application-for-social-security-card/index.ts
@@ -8,6 +8,7 @@ export default definePdf<PdfFieldName>({
   id: "ss5-application-for-social-security-card",
   title: "Application for Social Security Card",
   code: "SS-5",
+  canonicalUrl: "https://www.ssa.gov/forms/ss-5.pdf",
   pdfPath: pdf,
   resolver: (data) => ({
     newFirstName: data.newFirstName,

--- a/src/pdfs/ma/affidavit-of-indigency/index.ts
+++ b/src/pdfs/ma/affidavit-of-indigency/index.ts
@@ -7,6 +7,7 @@ export default definePdf<PdfFieldName>({
   id: "affidavit-of-indigency",
   title: "Affidavit of Indigency",
   jurisdiction: "MA",
+  canonicalUrl: "https://www.mass.gov/doc/affidavit-of-indigency/download",
   pdfPath: pdf,
   resolver: (data) => ({
     courtName: undefined,

--- a/src/pdfs/ma/cjp25-petition-to-change-name-of-minor/index.ts
+++ b/src/pdfs/ma/cjp25-petition-to-change-name-of-minor/index.ts
@@ -11,6 +11,8 @@ export default definePdf<PdfFieldName>({
   title: "Petition to Change Name of Minor",
   code: "CJP-25",
   jurisdiction: "MA",
+  canonicalUrl:
+    "https://www.mass.gov/doc/petition-to-change-name-of-minor-cjp-25/download",
   pdfPath: pdf,
   resolver: (data) => ({
     // Header

--- a/src/pdfs/ma/cjp27-petition-to-change-name-of-adult/index.ts
+++ b/src/pdfs/ma/cjp27-petition-to-change-name-of-adult/index.ts
@@ -10,6 +10,8 @@ export default definePdf<PdfFieldName>({
   title: "Petition to Change Name of Adult",
   code: "CJP-27",
   jurisdiction: "MA",
+  canonicalUrl:
+    "https://www.mass.gov/doc/petition-to-change-name-of-adult-cjp-27/download",
   pdfPath: pdf,
   resolver: (data) => ({
     petitionerFirstName: data.oldFirstName,

--- a/src/pdfs/ma/cjp34-cori-and-wms-release-request/index.ts
+++ b/src/pdfs/ma/cjp34-cori-and-wms-release-request/index.ts
@@ -9,6 +9,8 @@ export default definePdf<PdfFieldName>({
   title: "Court Activity Record Request Form",
   code: "CJP-34",
   jurisdiction: "MA",
+  canonicalUrl:
+    "https://www.mass.gov/doc/court-activity-record-information-and-warrant-management-system-release-request-form-cjp-34/download",
   pdfPath: pdf,
   resolver: (data) => ({
     county: data.residenceCounty,

--- a/src/pdfs/ri/background-check-authorization-of-release/index.ts
+++ b/src/pdfs/ri/background-check-authorization-of-release/index.ts
@@ -9,6 +9,7 @@ export default definePdf<PdfFieldName>({
   id: "background-check-authorization-of-release",
   title: "Background Check Authorization of Release",
   jurisdiction: "RI",
+  canonicalUrl: "https://riag.ri.gov/media/3906/download",
   pdfPath: pdf,
   resolver: (data) => ({
     fullName: joinNames(

--- a/src/pdfs/ri/pc8.1-change-of-name/index.ts
+++ b/src/pdfs/ri/pc8.1-change-of-name/index.ts
@@ -11,6 +11,8 @@ export default definePdf<PdfFieldName>({
   title: "Change of Name",
   code: "PC-8.1",
   jurisdiction: "RI",
+  canonicalUrl:
+    "https://docs.sos.ri.gov/documents/BusinessServices/PC8.1-change-of-name.pdf",
   pdfPath: pdf,
   resolver: (data) => {
     return {

--- a/src/pdfs/utils/__tests__/definePdf.test.ts
+++ b/src/pdfs/utils/__tests__/definePdf.test.ts
@@ -7,6 +7,7 @@ describe("definePdf", () => {
       id: "test-form" as any,
       title: "Test Form",
       jurisdiction: "MA",
+      canonicalUrl: "https://example.com",
       pdfPath: "public/forms/test-form.pdf",
       resolver: (data) => ({
         newFirstName: data.newFirstName,

--- a/src/pdfs/utils/__tests__/downloadMergedPdf.test.ts
+++ b/src/pdfs/utils/__tests__/downloadMergedPdf.test.ts
@@ -108,6 +108,7 @@ describe("downloadMergedPdf", () => {
       id: "test-form-2" as any,
       title: "Test Form 2",
       jurisdiction: "MA",
+      canonicalUrl: "https://example.com",
       pdfPath: "public/forms/test-form-2.pdf",
       resolver: (data) => ({ field1: data.newFirstName }),
     });

--- a/src/pdfs/utils/__tests__/downloadPdf.test.ts
+++ b/src/pdfs/utils/__tests__/downloadPdf.test.ts
@@ -100,6 +100,7 @@ describe("downloadPdf", () => {
       id: "test-form" as any,
       title: "Custom Form Name",
       jurisdiction: "MA",
+      canonicalUrl: "https://example.com",
       pdfPath: "public/forms/test-form.pdf",
       resolver: () => ({}),
     });

--- a/src/pdfs/utils/__tests__/helpers.ts
+++ b/src/pdfs/utils/__tests__/helpers.ts
@@ -7,6 +7,7 @@ export const testPdfDefinition = definePdf({
   id: "test-form" as any,
   title: "Test Form",
   jurisdiction: "MA",
+  canonicalUrl: "https://example.com",
   pdfPath: "public/forms/test-form.pdf",
   resolver: (data) => ({
     newFirstName: data.newFirstName,


### PR DESCRIPTION
This updates the `PDFDefinition` type to require a `canonicalUrl` string.

Adds a link to the top of the PDF Manager which opens the canonical URL.

Closes #576.

https://github.com/user-attachments/assets/9a08bfde-91bc-41e5-ae57-355c79f498db

