### PR TITLE
Fix broken links, update Lychee config

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -34,13 +34,17 @@ require_https = true
 # Base URL or website root directory to check relative URLs.
 base_url = "https://namesake.fyi"
 
-# Root path to use when checking absolute local links, must be an absolute path
-root_dir = "/dist"
-
 #############################  Exclusions  ##########################
 
 # Exclude these filesystem paths from getting checked.
 exclude_path = ["README.md", "\\.css$"]
+
+# Exclude URLs that block automated requests (403/timeout false positives).
+exclude = [
+    "https://19thnews.org/",
+    "https://www.jahonline.org/",
+    "https://ucmp.berkeley.edu/",
+]
 
 # Check mail addresses
 include_mail = true

--- a/src/content/posts/introducing-namesake/index.mdx
+++ b/src/content/posts/introducing-namesake/index.mdx
@@ -22,7 +22,7 @@ We hosted over fifteen virtual and in-person name change clinics with our commun
 
 We trained notaries, connected folks to outside resources, and made ourselves available just to listen and relate.
 
-We pushed for policy change like addressing discriminatory [credit reporting](https://pressley.house.gov/2023/03/31/pressley-unveils-bill-to-make-credit-reporting-system-more-inclusive-for-trans-nonbinary-folks/) and making [Transgender Day of Visibility official in Boston](https://www.boston.gov/news/transgender-day-visibility).
+We pushed for policy change like addressing discriminatory [credit reporting](https://pressley.house.gov/2023/03/31/pressley-unveils-bill-to-make-credit-reporting-system-more-inclusive-for-trans-nonbinary-folks/) and making Transgender Day of Visibility official in Boston.
 
 Since 2021, Namesake has helped over 500 people in Massachusetts update their legal name and gender markers, and we're ready to support more people in more places.
 


### PR DESCRIPTION
Lychee was reporting broken links; `/dist` was being prepended on relative links where it shouldn't have been. Fix. Exclude certain links that were 403ing.

Remove a dead link from boston.gov