### PR TITLE
Fix feedback radio style regression

### DIFF
--- a/src/components/forms/FormFeedback/FormFeedback.css
+++ b/src/components/forms/FormFeedback/FormFeedback.css
@@ -52,32 +52,47 @@
   }
 
   .form-feedback-sentiment-option {
-    flex-direction: column;
-    gap: var(--space-2xs);
-    justify-content: center;
     width: 100%;
     padding: var(--space-s) var(--space-m);
-    text-align: center;
     cursor: pointer;
     border: 1px solid var(--border-color);
     border-radius: var(--radius-xs);
+
+    .namesake-radio {
+      flex-direction: column;
+      gap: var(--space-2xs);
+      justify-content: center;
+      width: 100%;
+      text-align: center;
+      cursor: pointer;
+    }
 
     svg {
       flex-shrink: 0;
       margin-top: 4px;
     }
 
-    &::before {
+    .icon-filled {
+      display: none;
+    }
+
+    .namesake-radio::before {
       display: none;
     }
 
     &[data-selected] {
-      color: var(--highlight-foreground);
-      background: var(--highlight-background);
-      border-color: var(--highlight-background);
+      box-shadow: inset 0 0 0 2px var(--border-color);
+
+      .icon-outline {
+        display: none;
+      }
+
+      .icon-filled {
+        display: block;
+      }
     }
 
-    &[data-focus-visible] {
+    &:has(.namesake-radio[data-focus-visible]) {
       outline: 3px solid var(--focus-ring-color);
       outline-offset: 2px;
     }

--- a/src/components/forms/FormFeedback/FormFeedback.tsx
+++ b/src/components/forms/FormFeedback/FormFeedback.tsx
@@ -3,7 +3,9 @@ import {
   RiHandHeartLine,
   RiHeart3Line,
   RiShareForwardLine,
+  RiThumbDownFill,
   RiThumbDownLine,
+  RiThumbUpFill,
   RiThumbUpLine,
 } from "@remixicon/react";
 import { useActionState, useRef } from "react";
@@ -123,11 +125,13 @@ export function FormFeedback({ slug }: FormFeedbackProps) {
             defaultValue={isSubmitError(state) ? state.sentiment : undefined}
           >
             <Radio value="positive" className="form-feedback-sentiment-option">
-              <RiThumbUpLine size={24} aria-hidden />
+              <RiThumbUpLine size={24} aria-hidden className="icon-outline" />
+              <RiThumbUpFill size={24} aria-hidden className="icon-filled" />
               It was easy
             </Radio>
             <Radio value="negative" className="form-feedback-sentiment-option">
-              <RiThumbDownLine size={24} aria-hidden />
+              <RiThumbDownLine size={24} aria-hidden className="icon-outline" />
+              <RiThumbDownFill size={24} aria-hidden className="icon-filled" />
               Had some problems
             </Radio>
           </RadioGroup>


### PR DESCRIPTION
#554 introduced a regression on account of changes to React Aria's Radio markup.

Fix.

<img width="1368" height="310" alt="CleanShot 2026-06-08 at 10 37 14@2x" src="https://github.com/user-attachments/assets/8313d984-6c03-49a5-9888-c1093993f80c" />

<img width="1372" height="306" alt="CleanShot 2026-06-08 at 10 49 12@2x" src="https://github.com/user-attachments/assets/d69cf821-91df-4c61-ba8a-224e422da0ef" />
