### PR TITLE
Remove file format from config

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -22,11 +22,6 @@ export default defineConfig({
   integrations: [sitemap(), mdx(), react()],
   prefetch: true,
   trailingSlash: "never",
-  build: {
-    // Eliminate trailing slashes from Cloudflare Pages
-    // https://creativehike.com/posts/removing-trailng-slashes-astro
-    format: "file",
-  },
   fonts: [
     {
       provider: fontProviders.local(),


### PR DESCRIPTION
Test removing build format "file" from the Astro config.

The recent update to static rendering is now tracking `.html` extensions in Fathom.

Testing to see if removing this setting will fix that.