### PR TITLE
Add edit link to footer of all guide pages

### DIFF
--- a/src/components/EditLink.astro
+++ b/src/components/EditLink.astro
@@ -1,0 +1,29 @@
+---
+import { RiPencilLine } from "@remixicon/react";
+
+const { path } = Astro.props;
+
+const editUrl = `https://github.com/namesakefyi/namesake/edit/main/${path}`;
+---
+
+<a href={editUrl} target="_blank">
+  <RiPencilLine size={20} />Edit this page
+</a>
+
+<style>
+  a {
+    gap: 0.5rem;
+    align-items: center;
+    text-decoration: none;
+    display: inline-flex;
+    align-item: center;
+    font-size: var(--step--1);
+    color: var(--sl-color-gray-3);
+
+    @media (hover: hover) {
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+</style>

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -1,7 +1,7 @@
 ---
-
 import { type CollectionEntry, getCollection, render } from "astro:content";
 import type { BreadcrumbItem } from "../../components/Breadcrumbs.astro";
+import EditLink from "../../components/EditLink.astro";
 import TableOfContents from "../../components/TableOfContents.astro";
 import ProseLayout from "../../layouts/ProseLayout.astro";
 
@@ -35,4 +35,17 @@ const { Content, headings } = await render(guide);
 >
   <TableOfContents headings={headings} slot="toc" />
   <Content />
+  <footer>
+    <EditLink path={guide.filePath} />
+  </footer>
 </ProseLayout>
+
+<style>
+  footer {
+    display: flex;
+    justify-content: space-between;
+    padding-block-start: var(--space-s);
+    border-block-start: 1px solid var(--border-color);
+    margin-block-start: var(--space-2xl);
+  }
+</style>


### PR DESCRIPTION
Create a new `EditLink` component which opens the GitHub edit page for the current guide. Closes #589 

https://github.com/user-attachments/assets/c2b3af78-1c56-4318-b11f-281c39ee00c7



