### PR TITLE
Fix flaky Playwright tests in Webkit

### DIFF
--- a/src/content/forms/court-order-ma/e2e.spec.ts
+++ b/src/content/forms/court-order-ma/e2e.spec.ts
@@ -43,12 +43,11 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
     await expect(
       page.getByRole("heading", { name: "What is your new name?" }),
     ).toBeVisible();
-    await page.getByRole("textbox", { name: "First name" }).click();
+    await expect(
+      page.getByRole("textbox", { name: "First name" }),
+    ).toBeVisible();
     await page.getByRole("textbox", { name: "First name" }).fill("Marsha");
-
-    await page.getByRole("textbox", { name: "Middle name" }).click();
     await page.getByRole("textbox", { name: "Middle name" }).fill("P");
-    await page.getByRole("textbox", { name: "Last or family name" }).click();
     await page
       .getByRole("textbox", { name: "Last or family name" })
       .fill("Johnson");
@@ -59,11 +58,11 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
     await expect(
       page.getByRole("heading", { name: "What is your current legal name?" }),
     ).toBeVisible();
-    await page.getByRole("textbox", { name: "First name" }).click();
+    await expect(
+      page.getByRole("textbox", { name: "First name" }),
+    ).toBeVisible();
     await page.getByRole("textbox", { name: "First name" }).fill("My");
-    await page.getByRole("textbox", { name: "First name" }).press("Tab");
     await page.getByRole("textbox", { name: "Middle name" }).fill("Old");
-    await page.getByRole("textbox", { name: "Middle name" }).press("Tab");
     await page
       .getByRole("textbox", { name: "Last or family name" })
       .fill("Name");
@@ -78,7 +77,9 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
       }),
     ).toBeVisible();
 
-    await page.getByRole("textbox", { name: "Reason for name change" }).click();
+    await expect(
+      page.getByRole("textbox", { name: "Reason for name change" }),
+    ).toBeVisible();
     await expect(page.getByText("What do I write?")).toBeVisible();
     await page
       .getByRole("textbox", { name: "Reason for name change" })
@@ -90,12 +91,13 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
     await expect(
       page.getByRole("heading", { name: "What is your contact information?" }),
     ).toBeVisible();
-    await page.getByRole("textbox", { name: "Phone number" }).click();
+    await expect(
+      page.getByRole("textbox", { name: "Phone number" }),
+    ).toBeVisible();
     await page
       .getByRole("textbox", { name: "Phone number" })
       .fill("12345678901");
 
-    await page.getByRole("textbox", { name: "Email address" }).click();
     await page
       .getByRole("textbox", { name: "Email address" })
       .fill("test@email.com");
@@ -106,14 +108,11 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
     await expect(
       page.getByRole("heading", { name: "Where were you born?" }),
     ).toBeVisible();
-    await page.getByRole("textbox", { name: "City" }).click();
     await page.getByRole("textbox", { name: "City" }).fill("Birthcity");
-    await page.getByRole("combobox", { name: "Country" }).click();
     await page.getByRole("combobox", { name: "Country" }).fill("unite");
     await page
       .getByRole("option", { name: "United States of America" })
       .click();
-    await page.getByRole("combobox", { name: "State" }).click();
     await page.getByRole("combobox", { name: "State" }).fill("mas");
     await page.getByRole("option", { name: "Massachusetts" }).click();
     await page.getByRole("button", { name: "Continue" }).click();
@@ -216,10 +215,13 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
       }),
     ).toBeVisible();
     await page.getByText("Yes").click();
+    await expect(page.getByRole("grid", { name: "Pronouns" })).toBeVisible();
     await page.getByRole("row", { name: "they/them" }).click();
     await page.getByRole("row", { name: "she/her" }).click();
     await page.getByRole("row", { name: "other pronouns" }).click();
-    await page.getByRole("textbox", { name: "List other pronouns" }).click();
+    await expect(
+      page.getByRole("textbox", { name: "List other pronouns" }),
+    ).toBeVisible();
     await page
       .getByRole("textbox", { name: "List other pronouns" })
       .fill("zi/zir");

--- a/src/content/forms/court-order-ma/e2e.spec.ts
+++ b/src/content/forms/court-order-ma/e2e.spec.ts
@@ -147,9 +147,7 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
     await page.getByRole("textbox", { name: "City" }).press("Tab");
     await page.getByRole("combobox", { name: "State" }).fill("ma");
     await page.getByRole("option", { name: "Massachusetts" }).click();
-    await page.getByRole("textbox", { name: "County" }).click();
     await page.getByRole("textbox", { name: "County" }).fill("Suffolk");
-    await page.getByRole("textbox", { name: "ZIP" }).click();
     await page.getByRole("textbox", { name: "ZIP" }).fill("02108");
 
     await page.getByText("I use a different mailing address").click();

--- a/src/content/forms/court-order-ma/e2e.spec.ts
+++ b/src/content/forms/court-order-ma/e2e.spec.ts
@@ -109,10 +109,12 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
       page.getByRole("heading", { name: "Where were you born?" }),
     ).toBeVisible();
     await page.getByRole("textbox", { name: "City" }).fill("Birthcity");
+    await page.getByRole("combobox", { name: "Country" }).click();
     await page.getByRole("combobox", { name: "Country" }).fill("unite");
     await page
       .getByRole("option", { name: "United States of America" })
       .click();
+    await page.getByRole("combobox", { name: "State" }).click();
     await page.getByRole("combobox", { name: "State" }).fill("mas");
     await page.getByRole("option", { name: "Massachusetts" }).click();
     await page.getByRole("button", { name: "Continue" }).click();

--- a/src/content/forms/court-order-ma/e2e.spec.ts
+++ b/src/content/forms/court-order-ma/e2e.spec.ts
@@ -109,14 +109,16 @@ test("Massachusetts Court Order", async ({ page }, testInfo) => {
       page.getByRole("heading", { name: "Where were you born?" }),
     ).toBeVisible();
     await page.getByRole("textbox", { name: "City" }).fill("Birthcity");
-    await page.getByRole("combobox", { name: "Country" }).click();
-    await page.getByRole("combobox", { name: "Country" }).fill("unite");
-    await page
-      .getByRole("option", { name: "United States of America" })
-      .click();
-    await page.getByRole("combobox", { name: "State" }).click();
-    await page.getByRole("combobox", { name: "State" }).fill("mas");
-    await page.getByRole("option", { name: "Massachusetts" }).click();
+    const countryCombobox = page.getByRole("combobox", { name: "Country" });
+    await countryCombobox.fill("united sta");
+    await countryCombobox.press("ArrowDown");
+    await countryCombobox.press("Enter");
+
+    const stateCombobox = page.getByRole("combobox", { name: "State" });
+    await stateCombobox.fill("mass");
+    await stateCombobox.press("ArrowDown");
+    await stateCombobox.press("Enter");
+
     await page.getByRole("button", { name: "Continue" }).click();
   });
 

--- a/src/content/forms/court-order-ri/e2e.spec.ts
+++ b/src/content/forms/court-order-ri/e2e.spec.ts
@@ -95,8 +95,12 @@ test("Rhode Island Court Order", async ({ page }, testInfo) => {
       .getByRole("textbox", { name: "Street address" })
       .fill("100 Main St");
     await page.getByRole("textbox", { name: "City" }).fill("Providence");
-    await page.getByRole("combobox", { name: "State" }).click();
-    await page.getByRole("option", { name: "Rhode Island" }).click();
+
+    const stateCombobox = page.getByRole("combobox", { name: "State" });
+    await stateCombobox.fill("rhode is");
+    await stateCombobox.press("ArrowDown");
+    await stateCombobox.press("Enter");
+
     await page.getByRole("textbox", { name: "ZIP" }).fill("02903");
     await page.getByRole("button", { name: "Continue" }).click();
   });
@@ -132,13 +136,16 @@ test("Rhode Island Court Order", async ({ page }, testInfo) => {
       page.getByRole("heading", { name: "Where were you born?" }),
     ).toBeVisible();
     await page.getByRole("textbox", { name: "City" }).fill("Providence");
-    await page.getByRole("combobox", { name: "Country" }).click();
-    await page
-      .getByRole("option", { name: "United States of America" })
-      .click();
-    await expect(page.getByRole("combobox", { name: "State" })).toBeVisible();
-    await page.getByRole("combobox", { name: "State" }).click();
-    await page.getByRole("option", { name: "Rhode Island" }).click();
+
+    const countryCombobox = page.getByRole("combobox", { name: "Country" });
+    await countryCombobox.fill("united states");
+    await countryCombobox.press("ArrowDown");
+    await countryCombobox.press("Enter");
+
+    const stateCombobox = page.getByRole("combobox", { name: "State" });
+    await stateCombobox.fill("rhode is");
+    await stateCombobox.press("ArrowDown");
+    await stateCombobox.press("Enter");
     await page.getByRole("button", { name: "Continue" }).click();
   });
 
@@ -198,10 +205,14 @@ test("Rhode Island Court Order", async ({ page }, testInfo) => {
     await page
       .getByRole("textbox", { name: "Occupation" })
       .fill("Software Engineer");
-    await page
-      .getByRole("combobox", { name: "Marital status (optional)" })
-      .click();
-    await page.getByRole("option", { name: "Single" }).click();
+
+    const maritalStatusCombobox = page.getByRole("combobox", {
+      name: "Marital status (optional)",
+    });
+    await maritalStatusCombobox.fill("single");
+    await maritalStatusCombobox.press("ArrowDown");
+    await maritalStatusCombobox.press("Enter");
+
     await page.getByRole("button", { name: "Continue" }).click();
   });
 

--- a/src/content/forms/court-order-ri/e2e.spec.ts
+++ b/src/content/forms/court-order-ri/e2e.spec.ts
@@ -95,9 +95,7 @@ test("Rhode Island Court Order", async ({ page }, testInfo) => {
       .getByRole("textbox", { name: "Street address" })
       .fill("100 Main St");
     await page.getByRole("textbox", { name: "City" }).fill("Providence");
-    await page
-      .getByRole("combobox", { name: "State" })
-      .pressSequentially("rho");
+    await page.getByRole("combobox", { name: "State" }).click();
     await page.getByRole("option", { name: "Rhode Island" }).click();
     await page.getByRole("textbox", { name: "ZIP" }).fill("02903");
     await page.getByRole("button", { name: "Continue" }).click();
@@ -134,16 +132,12 @@ test("Rhode Island Court Order", async ({ page }, testInfo) => {
       page.getByRole("heading", { name: "Where were you born?" }),
     ).toBeVisible();
     await page.getByRole("textbox", { name: "City" }).fill("Providence");
-    await page
-      .getByRole("combobox", { name: "Country" })
-      .pressSequentially("unite");
+    await page.getByRole("combobox", { name: "Country" }).click();
     await page
       .getByRole("option", { name: "United States of America" })
       .click();
     await expect(page.getByRole("combobox", { name: "State" })).toBeVisible();
-    await page
-      .getByRole("combobox", { name: "State" })
-      .pressSequentially("rho");
+    await page.getByRole("combobox", { name: "State" }).click();
     await page.getByRole("option", { name: "Rhode Island" }).click();
     await page.getByRole("button", { name: "Continue" }).click();
   });
@@ -206,7 +200,7 @@ test("Rhode Island Court Order", async ({ page }, testInfo) => {
       .fill("Software Engineer");
     await page
       .getByRole("combobox", { name: "Marital status (optional)" })
-      .pressSequentially("Single");
+      .click();
     await page.getByRole("option", { name: "Single" }).click();
     await page.getByRole("button", { name: "Continue" }).click();
   });

--- a/src/content/forms/social-security/e2e.spec.ts
+++ b/src/content/forms/social-security/e2e.spec.ts
@@ -96,20 +96,26 @@ test("Social Security", async ({ page }, testInfo) => {
     await page
       .getByRole("textbox", { name: "City of birth" })
       .fill("Springfield");
-    await page.getByRole("combobox", { name: "Country" }).click();
-    await page.getByRole("combobox", { name: "Country" }).fill("can");
-    await page.getByRole("option", { name: "Canada" }).click();
-    await expect(page.getByRole("combobox", { name: "State" })).toHaveCount(0);
 
-    await page.getByRole("combobox", { name: "Country" }).click();
-    await page.getByRole("combobox", { name: "Country" }).fill("unite");
-    await page
-      .getByRole("option", { name: "United States of America" })
-      .click();
-    await expect(page.getByRole("combobox", { name: "State" })).toBeVisible();
-    await page.getByRole("combobox", { name: "State" }).click();
-    await page.getByRole("combobox", { name: "State" }).fill("mas");
-    await page.getByRole("option", { name: "Massachusetts" }).click();
+    const countryCombobox = page.getByRole("combobox", { name: "Country" });
+    await countryCombobox.fill("canada");
+    await countryCombobox.press("ArrowDown");
+    await countryCombobox.press("Enter");
+    await expect(countryCombobox).toHaveValue("Canada");
+
+    const stateCombobox = page.getByRole("combobox", { name: "State" });
+    await expect(stateCombobox).toHaveCount(0);
+
+    await countryCombobox.fill("united sta");
+    await countryCombobox.press("ArrowDown");
+    await countryCombobox.press("Enter");
+    await expect(countryCombobox).toHaveValue("United States of America");
+
+    await expect(stateCombobox).toBeVisible();
+    await stateCombobox.fill("mas");
+    await stateCombobox.press("ArrowDown");
+    await stateCombobox.press("Enter");
+    await expect(stateCombobox).toHaveValue("Massachusetts");
 
     await page.getByRole("button", { name: "Continue" }).click();
   });
@@ -285,9 +291,14 @@ test("Social Security", async ({ page }, testInfo) => {
       .getByRole("textbox", { name: "Street address" })
       .fill("200 Oak St");
     await page.getByRole("textbox", { name: "City" }).fill("Boston");
-    await page.getByRole("combobox", { name: "State" }).click();
-    await page.getByRole("combobox", { name: "State" }).fill("ma");
-    await page.getByRole("option", { name: "Massachusetts" }).click();
+
+    const stateCombobox = page.getByRole("combobox", { name: "State" });
+    await stateCombobox.click();
+    await stateCombobox.fill("mass");
+    await stateCombobox.press("ArrowDown");
+    await stateCombobox.press("Enter");
+    await expect(stateCombobox).toHaveValue("Massachusetts");
+
     await page.getByRole("textbox", { name: "ZIP" }).fill("02110");
     await page.getByRole("button", { name: "Continue" }).click();
   });


### PR DESCRIPTION
Use keyboard interactions to select entries from combobox in order to workaround issues with visibility and click targets on react-aria popovers. Resolves #593 

https://www.youtube.com/watch?v=CwfohDaRpig