### PR TITLE
Disable webkit Playwright runs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chromium, firefox, webkit]
+        browser: [chromium, firefox]
 
     steps:
       - name: Checkout code

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,10 +21,6 @@ export default defineConfig({
       name: "firefox",
       use: { ...devices["Desktop Firefox"] },
     },
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
   ],
   webServer: {
     command: "pnpm dev",


### PR DESCRIPTION
Still flaky and slow tests in webkit. Dunno exactly why. Found a 2022 issue that's marked resolved, but still having trouble specifically with webkit: https://github.com/microsoft/playwright/issues/12370

Maybe can come back to this in the future. Removing webkit test runs for now.