### PR TITLE
Fix lists and formatting in guides

### DIFF
--- a/src/content/guides/court-order-ma.mdx
+++ b/src/content/guides/court-order-ma.mdx
@@ -14,9 +14,8 @@ The court petition is a formal request to the state to legally change your name.
 
 To file, you will need:
 
-A certified copy of your birth certificate (long-form). This is available from the [Registry of Vital Records](https://www.mass.gov/ordering-a-certificate) or from the city or town where you were born.
-
-If you have changed your name in the past, you must file the certified document showing that name change for each time your name changed. Examples of this are a marriage certificate, Judgment of Divorce, or other court decree of name change.
+1. A certified copy of your birth certificate (long-form). This is available from the [Registry of Vital Records](https://www.mass.gov/ordering-a-certificate) or from the city or town where you were born.
+2. Past name change documents, if applicable. For example, a marriage certificate or Judgment of Divorce.
 
 <details>
 <summary>Can I change my name if I owe debt?</summary>

--- a/src/content/guides/court-order-ri.mdx
+++ b/src/content/guides/court-order-ri.mdx
@@ -13,15 +13,11 @@ The court petition is a formal request to the state to legally change your name.
 
 To file, you will need:
 
-A certified copy of your birth certificate.
-
-Proof of residency showing that you have lived in Rhode Island for at least 6 months.
-
-Records of any previous name changes, if applicable.
-
-A completed background check from the [Bureau of Criminal Identification and Investigation](https://riag.ri.gov/about-our-office/divisions-and-units/bureau-criminal-identification-bci). This is also called a “BCI check”.
-
-The signed and notarized Name Change Petition form.
+1. A certified copy of your birth certificate.
+2. Proof of residency showing that you have lived in Rhode Island for at least 6 months.
+3. Records of any previous name changes, if applicable.
+4. A completed background check from the [Bureau of Criminal Identification and Investigation](https://riag.ri.gov/about-our-office/divisions-and-units/bureau-criminal-identification-bci). This is also called a "BCI check".
+5. The signed and notarized Name Change Petition form.
 
 <details>
 <summary>What if I don't have a certified birth certificate?</summary>
@@ -105,24 +101,18 @@ If you send off the background check, you should receive the response within 1�
 
 To get a background check by mail, you will need:
 
-A signed and notarized Authorization of Release (included in the form download above)
-
-A copy of one valid form of photo identification:
-
-Valid state issued driver’s license (front and back), or
-
-Valid state issued identification card (front and back), or
-
-Valid United States passport
-
-Check or money order for $5.00, payable to “BCI.” Credit cards and cash are not accepted by mail.
-
-A return envelope stamped and addressed to you. Include this envelope _inside_ the envelope you use to send all of the documents. The office will use this envelope to send you your final background check report.
+1. A signed and notarized Authorization of Release (included in the form download above)
+2. A copy of one valid form of photo identification:
+   - Valid state issued driver's license (front and back), or
+   - Valid state issued identification card (front and back), or
+   - Valid United States passport
+3. Check or money order for $5.00, payable to “BCI.” Credit cards and cash are not accepted by mail.
+4. A return envelope stamped and addressed to you. Include this envelope _inside_ the envelope you use to send all of the documents. The office will use this envelope to send you your final background check report.
 
 Mail all documents, payment, and the return envelope to:
 
-**Rhode Island Office of The Attorney General**
-4 Howard Ave
+**Rhode Island Office of The Attorney General**  
+4 Howard Ave  
 Cranston, RI 02920
 
 </details>
@@ -132,23 +122,22 @@ Cranston, RI 02920
 
 To get a background check in person, you will need to travel to Cranston. Collect your Authorization of Release (included in the form download above) and one valid photo ID:
 
-Valid state issued driver’s license, or
-
-Valid state issued identification card, or
-
-Valid United States passport
+- Valid state issued driver's license, or
+- Valid state issued identification card, or
+- Valid United States passport
 
 Bring your documents to:
 
-**Rhode Island Attorney General Customer Service Center
-**[4 Howard Avenue
+**Rhode Island Attorney General  
+Customer Service Center**  
+[4 Howard Avenue  
 Cranston, RI 02920](https://maps.app.goo.gl/YG6D9ko4THR6QWUb6)
 
 Hours of operation are:
 
-Monday–Friday, 8:30 a.m.–4:30 p.m.
+**Monday–Friday, 8:30 a.m.–4:30 p.m.**  
 (Fingerprint process stops at 4:00 p.m.)
-_*Closed on state holidays_
+_Closed on state holidays._
 
 Upon arrival, check into the virtual line by using the QR code provided on signage throughout the parking lot. After getting into the virtual line, you will receive a welcome text. A second text message will let you know when the center is ready for you. Remain in your car or in the lobby until the center is ready to assist you.
 

--- a/src/content/guides/passport.mdx
+++ b/src/content/guides/passport.mdx
@@ -30,15 +30,11 @@ Get a new 2×2" passport photo. You can do this yourself, although we recommend 
 
 Assemble your documents in a mailing envelope:
 
-Completed, signed, and dated forms
-
-Your new passport photo
-
-Your old passport book and/or passport card
-
-Your certified court order
-
-A check for the required amount, made payable to the U.S. Department of State. [See all current Passport fees.](https://travel.state.gov/content/travel/en/passports/how-apply/fees.html)
+1. Completed, signed, and dated forms
+2. Your new passport photo
+3. Your old passport book and/or passport card
+4. Your certified court order
+5. A check for the required amount, made payable to the U.S. Department of State. [See all current Passport fees.](https://travel.state.gov/content/travel/en/passports/how-apply/fees.html)
 
 ## Mail documents
 
@@ -46,22 +42,23 @@ A check for the required amount, made payable to the U.S. Department of State. [
 
 If you want routine service and live in **California**, **Florida**, **Illinois**, **Minnesota**, **New York**, or **Texas**, mail to:
 
-National Passport Processing Center
-Post Office Box 640155
+**National Passport Processing Center**  
+Post Office Box 640155  
 Irving, TX 75064-0155
 
-If you want routine service and live in **any other state **or **Canada**, mail to:
+If you want routine service and live in **any other state** or **Canada**, mail to:
 
-National Passport Processing Center
-Post Office Box 90155
+**National Passport Processing Center**  
+Post Office Box 90155  
 Philadelphia, PA 19190-0155
 
 If you want **expedited service**, mail to:
 
-National Passport Processing Center
-Post Office Box 90955
+**National Passport Processing Center**  
+Post Office Box 90955  
 Philadelphia, PA 19190-0955
-Write “**EXPEDITE**” on the outside of the mailing envelope.
+
+_Write "**EXPEDITE**" on the outside of the mailing envelope._
 
 ## Wait for your new passport
 

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -245,9 +245,9 @@ const headerDescription =
     }
 
     details:not(:where(.not-content *)) {
-      --details-indent: var(--space-l);
       --details-transition-duration: 0.2s;
 
+      padding-inline-start: var(--space-2xl);
       transition-property: margin-block-start;
       transition-duration: var(--details-transition-duration);
       transition-timing-function: ease;
@@ -274,14 +274,16 @@ const headerDescription =
       &[open] summary::before {
         rotate: 90deg;
       }
+
+      & + details {
+        padding-block-start: var(--space-s);
+      }
     }
 
     summary:not(:where(.not-content *)) {
       display: inline-block;
       position: relative;
       list-style-type: none;
-      padding-inline-start: var(--details-indent);
-      padding-block: var(--space-2xs);
       font-weight: var(--weight-bold);
       cursor: pointer;
       margin: 0;
@@ -294,31 +296,15 @@ const headerDescription =
       &::before {
         content: "";
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M13.1717 12.0007L8.22192 7.05093L9.63614 5.63672L16.0001 12.0007L9.63614 18.3646L8.22192 16.9504L13.1717 12.0007Z'%3E%3C/path%3E%3C/svg%3E");
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: 75%;
         transition: rotate 0.15s ease-out;
         position: absolute;
-        left: -0.2em;
-        top: 0.35em;
-        width: var(--space-l);
-        height: var(--space-l);
-        font-size: 1em;
-        scale: 1.1;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        line-height: 0;
-      }
-    }
-
-    details > *:not(summary):not(:where(.not-content *)) {
-      padding-block-end: var(--space-s);
-      padding-inline-start: var(--details-indent);
-
-      &:first-of-type {
-        margin-block-start: 0;
-      }
-
-      &:last-child {
-        margin-block-end: 0;
+        left: calc(var(--space-2xl) * -1);
+        top: -0.05em;
+        width: 1lh;
+        height: 1lh;
       }
     }
   }


### PR DESCRIPTION
During the migration from Sanity, some list styles were lost.

Put back numbered and unordered lists where necessary.

In addition, line breaks that rely on 2 spaces at the end of a line in Markdown were lost. Reformat for displaying addresses.

Finally, modify detail/summary styles to use the same indent width as numbered lists, and slightly adjust spacing between elements.