### PR TITLE
Add fallback styles for browsers not yet supporting CSS `grid-lanes`

### DIFF
--- a/src/pages/guides/index.astro
+++ b/src/pages/guides/index.astro
@@ -37,12 +37,14 @@ const { generalGuides, guidesByState } = await getGuidesByState();
 <style>
   .guides {
     padding-block-end: var(--space-2xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xl);
 
     @supports (display: grid-lanes) {
       display: grid-lanes;
-      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
       flow-tolerance: 1em;
-      gap: var(--space-2xl);
     }
   }
 </style>


### PR DESCRIPTION
Just display content in a single column when `grid-lanes` are unavailable.