### PR TITLE
Mark Rhode Island as supported

### DIFF
--- a/src/content/guides/ma/birth-certificate.mdx
+++ b/src/content/guides/ma/birth-certificate.mdx
@@ -2,6 +2,7 @@
 title: Birth Certificate
 state: ma
 category: birth-certificate
+stub: true
 ---
 
 In Massachusetts, you can only update your birth certificate if you are also updating the sex designation. You cannot update a birth certificate if you are only changing names.

--- a/src/content/states/states.yml
+++ b/src/content/states/states.yml
@@ -126,7 +126,7 @@
   namesakeSupport: none
 - id: ri
   name: Rhode Island
-  namesakeSupport: prioritized
+  namesakeSupport: full
 - id: sc
   name: South Carolina
   namesakeSupport: none


### PR DESCRIPTION
- Update state data to mark full support for Rhode Island.
- Mark the Massachusetts birth certificate guide as a stub, since it needs more content.