### PR TITLE
Add print styles

### DIFF
--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -88,6 +88,7 @@ const pageTitle = Astro.url.pathname === "/" ? title : `${title} · Namesake`;
     </main>
     <Footer />
     <script>
+      // Print media lazy-loading bypass
       window.addEventListener('beforeprint', () => {
         document.querySelectorAll('img[loading]').forEach(img => {
           img.removeAttribute('loading');

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -8,6 +8,7 @@ import { siteInfo } from "#constants/site-info";
 import "../styles/base.css";
 import "../styles/reset.css";
 import "../styles/theme.css";
+import "../styles/print.css";
 
 export interface Props {
   title: string;
@@ -86,5 +87,12 @@ const pageTitle = Astro.url.pathname === "/" ? title : `${title} · Namesake`;
       <slot />
     </main>
     <Footer />
+    <script>
+      window.addEventListener('beforeprint', () => {
+        document.querySelectorAll('img[loading]').forEach(img => {
+          img.removeAttribute('loading');
+        });
+      });
+    </script>
   </body>
 </html>

--- a/web/src/styles/print.css
+++ b/web/src/styles/print.css
@@ -1,0 +1,36 @@
+/* These styles are only used when printing the page. */
+/* biome-ignore-all lint/complexity/noImportantStyles: print styles should always override site styles */
+
+@media print {
+  html,
+  body {
+    background-color: none;
+  }
+
+  body > *:not(main) {
+    display: none !important;
+  }
+
+  body::before,
+  body::after {
+    display: none;
+  }
+
+  .rough-annotation {
+    display: none; /* Would display in odd location due to loading delay. */
+  }
+
+  details::details-content {
+    height: auto !important;
+    content-visibility: visible !important;
+    opacity: 1 !important;
+  }
+
+  a[href]:not([href^="#"])::after {
+    content: " (" attr(href) ")";
+  }
+
+  abbr[title]::after {
+    content: " (" attr(title) ")";
+  }
+}


### PR DESCRIPTION
Closes #621

Adds `print.css` to style pages for printing. This stylesheet has purposely been made to target semantic descriptors and make minimal changes to reduce rigidity and avoid clashes with existing styles, while being flexible regarding potential future styles.

---

I've implemented it in such a way that there is no added complexity to the build or any print-specific build requirements. Alternative to the approach I chose, it could be incorporated into the public directory and referenced directly in the head, like so: `<link href="/public/styles/print.css" media="print" rel="stylesheet" />`.

There is no performance benefit to such an approach ([browsers download it regardless](https://blog.tomayac.com/2018/11/08/why-browsers-download-stylesheets-with-non-matching-media-queries-180513/)) but it could be considered nicer from a code-style perspective.