### PR TITLE
Use `defineStep()` for step definitions

### DIFF
--- a/src/content/forms/affidavit-of-indigency-ma/steps/AddressStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/AddressStep.tsx
@@ -5,12 +5,12 @@ import {
   FormStep,
   useFieldVisible,
 } from "../../../../components/forms/FormStep";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
 const whenNotUnhoused = (data: Record<string, unknown>) =>
   data.isCurrentlyUnhoused !== true;
 
-export const addressStep: Step = {
+export const addressStep = defineStep({
   id: "address",
   title: "What is your residential address?",
   fields: [
@@ -52,4 +52,4 @@ export const addressStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/affidavit-of-indigency-ma/steps/CurrentNameStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/CurrentNameStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const currentNameStep: Step = {
+export const currentNameStep = defineStep({
   id: "current-name",
   title: "What is your current legal name?",
   description:
@@ -13,4 +13,4 @@ export const currentNameStep: Step = {
       <NameField type="oldName" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/affidavit-of-indigency-ma/steps/ExtraFeesStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/ExtraFeesStep.tsx
@@ -6,7 +6,7 @@ import {
 } from "../../../../components/forms/FormStep";
 import { NumberField } from "../../../../components/forms/NumberField";
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
 const amountProps = {
   label: "Amount (if known)",
@@ -18,7 +18,7 @@ const amountProps = {
   },
 } as const;
 
-export const extraFeesStep: Step = {
+export const extraFeesStep = defineStep({
   id: "extra-fees",
   title: "Do you need any other costs waived?",
   description:
@@ -122,4 +122,4 @@ export const extraFeesStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/affidavit-of-indigency-ma/steps/IncomePovertyStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/IncomePovertyStep.tsx
@@ -4,7 +4,7 @@ import { Banner } from "../../../../components/common/Banner";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { NumberField } from "../../../../components/forms/NumberField";
 import { RadioGroupField } from "../../../../components/forms/RadioGroupField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 import type { PovertyGuideline } from "../../../../utils/fetchPovertyGuideline";
 import { fetchPovertyGuideline } from "../../../../utils/fetchPovertyGuideline";
 import "./IncomePovertyStep.css";
@@ -161,7 +161,7 @@ function PovertyResult({
   );
 }
 
-export const incomePovertyStep: Step = {
+export const incomePovertyStep = defineStep({
   id: "income-poverty",
   title: "What is your income after taxes?",
   description:
@@ -232,4 +232,4 @@ export const incomePovertyStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/affidavit-of-indigency-ma/steps/IndigencyBasisStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/IndigencyBasisStep.tsx
@@ -2,9 +2,9 @@ import { useFormContext } from "react-hook-form";
 import { Banner } from "../../../../components/common/Banner";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { RadioGroupField } from "../../../../components/forms/RadioGroupField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const indigencyBasisStep: Step = {
+export const indigencyBasisStep = defineStep({
   id: "indigency-basis",
   title: "Why are you requesting a fee waiver?",
   fields: ["indigencyBasis"],
@@ -56,4 +56,4 @@ export const indigencyBasisStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/affidavit-of-indigency-ma/steps/NormalFeesStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/NormalFeesStep.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../../../components/forms/FormStep";
 import { NumberField } from "../../../../components/forms/NumberField";
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
 const amountProps = {
   label: "Amount (if known)",
@@ -20,7 +20,7 @@ const amountProps = {
   },
 } as const;
 
-export const normalFeesStep: Step = {
+export const normalFeesStep = defineStep({
   id: "normal-fees",
   title: "Which court fees would you like waived?",
   description: "Check all that apply. Enter the amount if you know it.",
@@ -114,4 +114,4 @@ export const normalFeesStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/affidavit-of-indigency-ma/steps/PublicAssistanceStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/PublicAssistanceStep.tsx
@@ -1,8 +1,8 @@
 import { CheckboxField } from "../../../../components/forms/CheckboxField";
 import { FormStep } from "../../../../components/forms/FormStep";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const publicAssistanceStep: Step = {
+export const publicAssistanceStep = defineStep({
   id: "public-assistance",
   title: "Which type of public assistance do you receive?",
   description: "Check all that apply.",
@@ -35,4 +35,4 @@ export const publicAssistanceStep: Step = {
       />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/AddressStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/AddressStep.tsx
@@ -1,9 +1,9 @@
 import { AddressField } from "../../../../components/forms/AddressField";
 import { FormStep } from "../../../../components/forms/FormStep";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 
-export const addressStep: Step = {
+export const addressStep = defineStep({
   id: "address",
   title: (data) => `What is ${nameOrFallback(data, "the minor")}'s address?`,
   description: (data) =>
@@ -22,4 +22,4 @@ export const addressStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/BirthCerticiateParentsStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/BirthCerticiateParentsStep.tsx
@@ -1,9 +1,9 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { YesNoField } from "../../../../components/forms/YesNoField";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 
-export const birthCertificateParentsStep: Step = {
+export const birthCertificateParentsStep = defineStep({
   id: "birth-certificate-parents",
   title: (data) =>
     `Are both parents listed on ${nameOrFallback(data, "the minor")}'s birth certificate?`,
@@ -19,4 +19,4 @@ export const birthCertificateParentsStep: Step = {
       />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/BirthplaceStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/BirthplaceStep.tsx
@@ -6,10 +6,10 @@ import {
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
 import { COUNTRIES } from "../../../../constants/countries";
 import { JURISDICTIONS } from "../../../../constants/jurisdictions";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 
-export const birthplaceStep: Step = {
+export const birthplaceStep = defineStep({
   id: "birthplace",
   title: (data) => `Where was ${nameOrFallback(data, "the minor")} born?`,
   fields: [
@@ -45,4 +45,4 @@ export const birthplaceStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/CoGuardianStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/CoGuardianStep.tsx
@@ -10,10 +10,10 @@ import { PhoneField } from "../../../../components/forms/PhoneField";
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
 import { JURISDICTIONS } from "../../../../constants/jurisdictions";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 
-export const coGuardianStep: Step = {
+export const coGuardianStep = defineStep({
   id: "co-guardian",
   title: (data) =>
     `Does ${nameOrFallback(data, "the minor")} have a court-appointed co-guardian?`,
@@ -65,7 +65,7 @@ export const coGuardianStep: Step = {
       </FormStep>
     );
   },
-};
+});
 
 function CoGuardianStateField() {
   const { control } = useFormContext();

--- a/src/content/forms/court-order-ma-minor/steps/ConsentStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ConsentStep.tsx
@@ -5,9 +5,9 @@ import {
 } from "../../../../components/forms/FormStep";
 import { LongTextField } from "../../../../components/forms/LongTextField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const consentStep: Step = {
+export const consentStep = defineStep({
   id: "consent",
   title: "Does everyone consent to the name change?",
   fields: [
@@ -79,4 +79,4 @@ export const consentStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/CurrentNameStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/CurrentNameStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const currentNameStep: Step = {
+export const currentNameStep = defineStep({
   id: "current-name",
   title: (data) =>
     `What is ${data.newFirstName ?? "the minor"}'s current legal name?`,
@@ -14,4 +14,4 @@ export const currentNameStep: Step = {
       <NameField type="oldName" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/DateOfBirthStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/DateOfBirthStep.tsx
@@ -2,11 +2,11 @@ import { useFormContext } from "react-hook-form";
 import { Banner } from "../../../../components/common/Banner";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { MemorableDateField } from "../../../../components/forms/MemorableDateField";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 import { deriveCurrentAge } from "../../../../utils/deriveCurrentAge";
 
-export const dateOfBirthStep: Step = {
+export const dateOfBirthStep = defineStep({
   id: "date-of-birth",
   title: (data) =>
     `What is ${nameOrFallback(data, "the minor")}'s date of birth?`,
@@ -40,4 +40,4 @@ export const dateOfBirthStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/GuardianStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/GuardianStep.tsx
@@ -10,10 +10,10 @@ import { PhoneField } from "../../../../components/forms/PhoneField";
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
 import { JURISDICTIONS } from "../../../../constants/jurisdictions";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 
-export const guardianStep: Step = {
+export const guardianStep = defineStep({
   id: "guardian",
   title: (data) =>
     `Does ${nameOrFallback(data, "the minor")} have a court-appointed guardian?`,
@@ -58,7 +58,7 @@ export const guardianStep: Step = {
       </FormStep>
     );
   },
-};
+});
 
 function GuardianStateField() {
   const { control } = useFormContext();

--- a/src/content/forms/court-order-ma-minor/steps/InterpreterStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/InterpreterStep.tsx
@@ -5,9 +5,9 @@ import {
   useFieldVisible,
 } from "../../../../components/forms/FormStep";
 import { LanguageSelectField } from "../../../../components/forms/LanguageSelectField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const interpreterStep: Step = {
+export const interpreterStep = defineStep({
   id: "interpreter",
   title: "If there is a hearing, does anyone need an interpreter?",
   description: "In most cases, a hearing is not required.",
@@ -51,4 +51,4 @@ export const interpreterStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/NewNameStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/NewNameStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const newNameStep: Step = {
+export const newNameStep = defineStep({
   id: "new-name",
   title: "What is the minor's new name?",
   description: "This is the name being made official!",
@@ -12,4 +12,4 @@ export const newNameStep: Step = {
       <NameField type="newName" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/ParentAddressStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ParentAddressStep.tsx
@@ -7,10 +7,10 @@ import {
   FormSubsection,
   useFieldVisible,
 } from "../../../../components/forms/FormStep";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 
-export const parentAddressStep: Step = {
+export const parentAddressStep = defineStep({
   id: "parent-address",
   title: (data) =>
     `Where do ${nameOrFallback(data, "the minor")}'s parents live?`,
@@ -90,4 +90,4 @@ export const parentAddressStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/ParentInfoStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ParentInfoStep.tsx
@@ -5,10 +5,10 @@ import {
 } from "../../../../components/forms/FormStep";
 import { PhoneField } from "../../../../components/forms/PhoneField";
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 
-export const parentInfoStep: Step = {
+export const parentInfoStep = defineStep({
   id: "parent-info",
   title: "What are both parents' information?",
   description: (data) =>
@@ -35,4 +35,4 @@ export const parentInfoStep: Step = {
       </FormSubsection>
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/ParentalRightsTerminatedStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ParentalRightsTerminatedStep.tsx
@@ -2,9 +2,9 @@ import { useFormContext } from "react-hook-form";
 import { Banner } from "../../../../components/common/Banner";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const parentalRightsTerminatedStep: Step = {
+export const parentalRightsTerminatedStep = defineStep({
   id: "parental-rights-terminated",
   title: "Has either parent had their parental rights terminated?",
   fields: ["hasLegalParentHadParentalRightsTerminated"],
@@ -28,4 +28,4 @@ export const parentalRightsTerminatedStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/ParentsDeceasedStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ParentsDeceasedStep.tsx
@@ -2,10 +2,10 @@ import { useFormContext } from "react-hook-form";
 import { Banner } from "../../../../components/common/Banner";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { YesNoField } from "../../../../components/forms/YesNoField";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 
-export const parentsDeceasedStep: Step = {
+export const parentsDeceasedStep = defineStep({
   id: "parent-deceased",
   title: (data) =>
     `Are any of ${nameOrFallback(data, "the minor")}'s legal parents deceased?`,
@@ -31,4 +31,4 @@ export const parentsDeceasedStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/PresentedByStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/PresentedByStep.tsx
@@ -1,8 +1,8 @@
 import { CheckboxField } from "../../../../components/forms/CheckboxField";
 import { FormStep } from "../../../../components/forms/FormStep";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const presentedByStep: Step = {
+export const presentedByStep = defineStep({
   id: "presented-by",
   title: "Who is presenting this petition?",
   description: "Select all that apply.",
@@ -27,4 +27,4 @@ export const presentedByStep: Step = {
       />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/PreviousNameChangeStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/PreviousNameChangeStep.tsx
@@ -6,10 +6,10 @@ import {
 import { LongTextField } from "../../../../components/forms/LongTextField";
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 
-export const previousNameChangeStep: Step = {
+export const previousNameChangeStep = defineStep({
   id: "previous-name-change",
   title: (data) =>
     `Has ${nameOrFallback(data, "the minor")} ever changed their legal name before?`,
@@ -40,4 +40,4 @@ export const previousNameChangeStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/PronounsStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/PronounsStep.tsx
@@ -5,10 +5,10 @@ import {
 } from "../../../../components/forms/FormStep";
 import { PronounSelectField } from "../../../../components/forms/PronounSelectField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 
-export const pronounsStep: Step = {
+export const pronounsStep = defineStep({
   id: "pronouns",
   title: (data) =>
     `Do you want to share ${nameOrFallback(data, "the minor")}'s pronouns with the court staff?`,
@@ -35,4 +35,4 @@ export const pronounsStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/ReasonStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ReasonStep.tsx
@@ -1,10 +1,10 @@
 import { Banner } from "../../../../components/common/Banner";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { LongTextField } from "../../../../components/forms/LongTextField";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 
-export const reasonStep: Step = {
+export const reasonStep = defineStep({
   id: "reason",
   title: (data) =>
     `What is the reason ${nameOrFallback(data, "the minor")} is changing names?`,
@@ -32,4 +32,4 @@ export const reasonStep: Step = {
       </Banner>
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma-minor/steps/YouthServicesStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/YouthServicesStep.tsx
@@ -1,9 +1,9 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { YesNoField } from "../../../../components/forms/YesNoField";
+import { defineStep } from "../../../../forms/defineStep";
 import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import type { Step } from "../../../../forms/types";
 
-export const youthServicesStep: Step = {
+export const youthServicesStep = defineStep({
   id: "youth-services",
   title: (data) =>
     `Is ${nameOrFallback(data, "the minor")} under the supervision of the Massachusetts Department of Youth Services?`,
@@ -19,4 +19,4 @@ export const youthServicesStep: Step = {
       />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma/steps/AddressStep.tsx
+++ b/src/content/forms/court-order-ma/steps/AddressStep.tsx
@@ -6,7 +6,7 @@ import {
   FormSubsection,
   useFieldVisible,
 } from "../../../../components/forms/FormStep";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
 const whenNotUnhoused = (data: Record<string, unknown>) =>
   data.isCurrentlyUnhoused !== true;
@@ -15,7 +15,7 @@ const whenMailing = (data: Record<string, unknown>) =>
   data.isCurrentlyUnhoused !== true &&
   data.isMailingAddressDifferentFromResidence === true;
 
-export const addressStep: Step = {
+export const addressStep = defineStep({
   id: "address",
   title: "What is your residential address?",
   description:
@@ -85,4 +85,4 @@ export const addressStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma/steps/BirthplaceStep.tsx
+++ b/src/content/forms/court-order-ma/steps/BirthplaceStep.tsx
@@ -6,9 +6,9 @@ import {
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
 import { COUNTRIES } from "../../../../constants/countries";
 import { JURISDICTIONS } from "../../../../constants/jurisdictions";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const birthplaceStep: Step = {
+export const birthplaceStep = defineStep({
   id: "birthplace",
   title: "Where were you born?",
   fields: [
@@ -47,4 +47,4 @@ export const birthplaceStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma/steps/ContactInfoStep.tsx
+++ b/src/content/forms/court-order-ma/steps/ContactInfoStep.tsx
@@ -1,9 +1,9 @@
 import { EmailField } from "../../../../components/forms/EmailField";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { PhoneField } from "../../../../components/forms/PhoneField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const contactInfoStep: Step = {
+export const contactInfoStep = defineStep({
   id: "contact-info",
   title: "What is your contact information?",
   description:
@@ -15,4 +15,4 @@ export const contactInfoStep: Step = {
       <EmailField name="email" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma/steps/CurrentNameStep.tsx
+++ b/src/content/forms/court-order-ma/steps/CurrentNameStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const currentNameStep: Step = {
+export const currentNameStep = defineStep({
   id: "current-name",
   title: "What is your current legal name?",
   description:
@@ -13,4 +13,4 @@ export const currentNameStep: Step = {
       <NameField type="oldName" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma/steps/DateOfBirthStep.tsx
+++ b/src/content/forms/court-order-ma/steps/DateOfBirthStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { MemorableDateField } from "../../../../components/forms/MemorableDateField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const dateOfBirthStep: Step = {
+export const dateOfBirthStep = defineStep({
   id: "date-of-birth",
   title: "What is your date of birth?",
   fields: ["dateOfBirth"],
@@ -11,4 +11,4 @@ export const dateOfBirthStep: Step = {
       <MemorableDateField name="dateOfBirth" label="Date of birth" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma/steps/ImpoundCaseStep.tsx
+++ b/src/content/forms/court-order-ma/steps/ImpoundCaseStep.tsx
@@ -6,9 +6,9 @@ import {
 } from "../../../../components/forms/FormStep";
 import { LongTextField } from "../../../../components/forms/LongTextField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const impoundCaseStep: Step = {
+export const impoundCaseStep = defineStep({
   id: "impound-case",
   title: "Would you like to impound your case?",
   description:
@@ -62,4 +62,4 @@ export const impoundCaseStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma/steps/InterpreterStep.tsx
+++ b/src/content/forms/court-order-ma/steps/InterpreterStep.tsx
@@ -5,9 +5,9 @@ import {
 } from "../../../../components/forms/FormStep";
 import { LanguageSelectField } from "../../../../components/forms/LanguageSelectField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const interpreterStep: Step = {
+export const interpreterStep = defineStep({
   id: "interpreter",
   title:
     "If there is a hearing for your name change, do you need an interpreter?",
@@ -33,4 +33,4 @@ export const interpreterStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma/steps/MothersMaidenNameStep.tsx
+++ b/src/content/forms/court-order-ma/steps/MothersMaidenNameStep.tsx
@@ -1,9 +1,9 @@
 import { Banner } from "../../../../components/common/Banner";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const mothersMaidenNameStep: Step = {
+export const mothersMaidenNameStep = defineStep({
   id: "mothers-maiden-name",
   title: "What is your mother's maiden name?",
   description:
@@ -18,4 +18,4 @@ export const mothersMaidenNameStep: Step = {
       </Banner>
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma/steps/NewNameStep.tsx
+++ b/src/content/forms/court-order-ma/steps/NewNameStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const newNameStep: Step = {
+export const newNameStep = defineStep({
   id: "new-name",
   title: "What is your new name?",
   description:
@@ -13,4 +13,4 @@ export const newNameStep: Step = {
       <NameField type="newName" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ma/steps/OtherNamesStep.tsx
+++ b/src/content/forms/court-order-ma/steps/OtherNamesStep.tsx
@@ -6,9 +6,9 @@ import {
 } from "../../../../components/forms/FormStep";
 import { LongTextField } from "../../../../components/forms/LongTextField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const otherNamesStep: Step = {
+export const otherNamesStep = defineStep({
   id: "other-names",
   title: "Have you ever used any other name or alias?",
   description:
@@ -50,4 +50,4 @@ export const otherNamesStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma/steps/PreviousNameChangeStep.tsx
+++ b/src/content/forms/court-order-ma/steps/PreviousNameChangeStep.tsx
@@ -6,9 +6,9 @@ import {
 import { LongTextField } from "../../../../components/forms/LongTextField";
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const previousNameChangeStep: Step = {
+export const previousNameChangeStep = defineStep({
   id: "previous-name-change",
   title: "Have you ever changed your name before?",
   fields: [
@@ -40,4 +40,4 @@ export const previousNameChangeStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma/steps/PronounsStep.tsx
+++ b/src/content/forms/court-order-ma/steps/PronounsStep.tsx
@@ -5,9 +5,9 @@ import {
 } from "../../../../components/forms/FormStep";
 import { PronounSelectField } from "../../../../components/forms/PronounSelectField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const pronounsStep: Step = {
+export const pronounsStep = defineStep({
   id: "pronouns",
   title: "Do you want to share your pronouns with the court staff?",
   fields: [
@@ -33,4 +33,4 @@ export const pronounsStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ma/steps/ReasonStep.tsx
+++ b/src/content/forms/court-order-ma/steps/ReasonStep.tsx
@@ -2,9 +2,9 @@ import { Banner } from "../../../../components/common/Banner";
 import { CheckboxField } from "../../../../components/forms/CheckboxField";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { LongTextField } from "../../../../components/forms/LongTextField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const reasonStep: Step = {
+export const reasonStep = defineStep({
   id: "reason",
   title: "What is the reason you're changing your name?",
   fields: [
@@ -38,4 +38,4 @@ export const reasonStep: Step = {
       />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ri/steps/AddressStep.tsx
+++ b/src/content/forms/court-order-ri/steps/AddressStep.tsx
@@ -6,9 +6,9 @@ import {
   FormSubsection,
   useFieldVisible,
 } from "../../../../components/forms/FormStep";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const addressStep: Step = {
+export const addressStep = defineStep({
   id: "address",
   title: "What is your residential address?",
   description:
@@ -78,4 +78,4 @@ export const addressStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ri/steps/BirthCertificateStep.tsx
+++ b/src/content/forms/court-order-ri/steps/BirthCertificateStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const birthCertificateStep: Step = {
+export const birthCertificateStep = defineStep({
   id: "birth-certificate",
   title: "Do you want to update your Rhode Island birth certificate?",
   fields: ["shouldChangeBirthCertificate"],
@@ -17,4 +17,4 @@ export const birthCertificateStep: Step = {
       />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ri/steps/BirthplaceStep.tsx
+++ b/src/content/forms/court-order-ri/steps/BirthplaceStep.tsx
@@ -6,9 +6,9 @@ import {
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
 import { COUNTRIES } from "../../../../constants/countries";
 import { JURISDICTIONS } from "../../../../constants/jurisdictions";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const birthplaceStep: Step = {
+export const birthplaceStep = defineStep({
   id: "birthplace",
   title: "Where were you born?",
   fields: [
@@ -47,4 +47,4 @@ export const birthplaceStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ri/steps/ContactInfoStep.tsx
+++ b/src/content/forms/court-order-ri/steps/ContactInfoStep.tsx
@@ -1,9 +1,9 @@
 import { EmailField } from "../../../../components/forms/EmailField";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { PhoneField } from "../../../../components/forms/PhoneField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const contactInfoStep: Step = {
+export const contactInfoStep = defineStep({
   id: "contact-info",
   title: "What is your contact information?",
   description:
@@ -15,4 +15,4 @@ export const contactInfoStep: Step = {
       <EmailField name="email" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ri/steps/CurrentNameStep.tsx
+++ b/src/content/forms/court-order-ri/steps/CurrentNameStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const currentNameStep: Step = {
+export const currentNameStep = defineStep({
   id: "current-name",
   title: "What is your current legal name?",
   description:
@@ -13,4 +13,4 @@ export const currentNameStep: Step = {
       <NameField type="oldName" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ri/steps/DateOfBirthStep.tsx
+++ b/src/content/forms/court-order-ri/steps/DateOfBirthStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { MemorableDateField } from "../../../../components/forms/MemorableDateField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const dateOfBirthStep: Step = {
+export const dateOfBirthStep = defineStep({
   id: "date-of-birth",
   title: "What is your date of birth?",
   fields: ["dateOfBirth"],
@@ -11,4 +11,4 @@ export const dateOfBirthStep: Step = {
       <MemorableDateField name="dateOfBirth" label="Date of birth" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ri/steps/FamilyInfoStep.tsx
+++ b/src/content/forms/court-order-ri/steps/FamilyInfoStep.tsx
@@ -3,9 +3,9 @@ import {
   FormSubsection,
 } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const familyInfoStep: Step = {
+export const familyInfoStep = defineStep({
   id: "family-info",
   title: "What are your parents' names?",
   fields: [
@@ -26,4 +26,4 @@ export const familyInfoStep: Step = {
       </FormSubsection>
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ri/steps/NewNameStep.tsx
+++ b/src/content/forms/court-order-ri/steps/NewNameStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const newNameStep: Step = {
+export const newNameStep = defineStep({
   id: "new-name",
   title: "What is your new name?",
   description:
@@ -13,4 +13,4 @@ export const newNameStep: Step = {
       <NameField type="newName" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ri/steps/PersonalInfoStep.tsx
+++ b/src/content/forms/court-order-ri/steps/PersonalInfoStep.tsx
@@ -1,7 +1,7 @@
 import { ComboBoxField } from "../../../../components/forms/ComboBoxField";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
 const MARITAL_STATUS_OPTIONS = [
   { label: "Single", value: "Single" },
@@ -10,7 +10,7 @@ const MARITAL_STATUS_OPTIONS = [
   { label: "Widowed", value: "Widowed" },
 ];
 
-export const personalInfoStep: Step = {
+export const personalInfoStep = defineStep({
   id: "personal-info",
   title: "What is your occupation and marital status?",
   fields: ["occupation", "maritalStatus"],
@@ -25,4 +25,4 @@ export const personalInfoStep: Step = {
       />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ri/steps/PreviousAddressesStep.tsx
+++ b/src/content/forms/court-order-ri/steps/PreviousAddressesStep.tsx
@@ -1,9 +1,9 @@
 import { TextField } from "../../../../components/common/TextField";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { RepeatingEntry } from "../../../../components/forms/RepeatingEntry";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const previousAddressesStep: Step = {
+export const previousAddressesStep = defineStep({
   id: "previous-addresses",
   title: "What are your most recent addresses?",
   description:
@@ -28,4 +28,4 @@ export const previousAddressesStep: Step = {
       </RepeatingEntry>
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/court-order-ri/steps/PreviousNameChangeStep.tsx
+++ b/src/content/forms/court-order-ri/steps/PreviousNameChangeStep.tsx
@@ -2,9 +2,9 @@ import { useFormContext } from "react-hook-form";
 import { Banner } from "../../../../components/common/Banner";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const previousNameChangeStep: Step = {
+export const previousNameChangeStep = defineStep({
   id: "previous-name-change",
   title: "Have you ever changed your name before?",
   fields: ["hasPreviousNameChange"],
@@ -29,4 +29,4 @@ export const previousNameChangeStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/court-order-ri/steps/ReasonStep.tsx
+++ b/src/content/forms/court-order-ri/steps/ReasonStep.tsx
@@ -1,9 +1,9 @@
 import { Banner } from "../../../../components/common/Banner";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { LongTextField } from "../../../../components/forms/LongTextField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const reasonStep: Step = {
+export const reasonStep = defineStep({
   id: "reason",
   title: "What is the reason you're changing your name?",
   fields: ["reasonForChangingName"],
@@ -30,4 +30,4 @@ export const reasonStep: Step = {
       </Banner>
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/social-security/steps/AddressStep.tsx
+++ b/src/content/forms/social-security/steps/AddressStep.tsx
@@ -1,8 +1,8 @@
 import { AddressField } from "../../../../components/forms/AddressField";
 import { FormStep } from "../../../../components/forms/FormStep";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const addressStep: Step = {
+export const addressStep = defineStep({
   id: "address",
   title: "What is your mailing address?",
   fields: [
@@ -17,4 +17,4 @@ export const addressStep: Step = {
       <AddressField type="mailing" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/social-security/steps/BirthplaceStep.tsx
+++ b/src/content/forms/social-security/steps/BirthplaceStep.tsx
@@ -6,9 +6,9 @@ import {
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
 import { COUNTRIES } from "../../../../constants/countries";
 import { JURISDICTIONS } from "../../../../constants/jurisdictions";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const birthplaceStep: Step = {
+export const birthplaceStep = defineStep({
   id: "birthplace",
   title: "Where were you born?",
   fields: [
@@ -47,4 +47,4 @@ export const birthplaceStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/social-security/steps/CitizenshipStep.tsx
+++ b/src/content/forms/social-security/steps/CitizenshipStep.tsx
@@ -2,9 +2,9 @@ import { useFormContext } from "react-hook-form";
 import { Banner } from "../../../../components/common/Banner";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { RadioGroupField } from "../../../../components/forms/RadioGroupField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const citizenshipStep: Step = {
+export const citizenshipStep = defineStep({
   id: "citizenship",
   title: "What is your citizenship status?",
   fields: ["citizenshipStatus"],
@@ -42,4 +42,4 @@ export const citizenshipStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/social-security/steps/DateOfBirthStep.tsx
+++ b/src/content/forms/social-security/steps/DateOfBirthStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { MemorableDateField } from "../../../../components/forms/MemorableDateField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const dateOfBirthStep: Step = {
+export const dateOfBirthStep = defineStep({
   id: "date-of-birth",
   title: "What is your date of birth?",
   fields: ["dateOfBirth"],
@@ -11,4 +11,4 @@ export const dateOfBirthStep: Step = {
       <MemorableDateField name="dateOfBirth" label="Date of birth" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/social-security/steps/EthnicityStep.tsx
+++ b/src/content/forms/social-security/steps/EthnicityStep.tsx
@@ -1,9 +1,9 @@
 import { Banner } from "../../../../components/common/Banner";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const ethnicityStep: Step = {
+export const ethnicityStep = defineStep({
   id: "ethnicity",
   title: "What is your ethnicity?",
   description:
@@ -24,4 +24,4 @@ export const ethnicityStep: Step = {
       </Banner>
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/social-security/steps/FilingForSomeoneElseStep.tsx
+++ b/src/content/forms/social-security/steps/FilingForSomeoneElseStep.tsx
@@ -6,9 +6,9 @@ import {
 import { RadioGroupField } from "../../../../components/forms/RadioGroupField";
 import { ShortTextField } from "../../../../components/forms/ShortTextField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const filingForSomeoneElseStep: Step = {
+export const filingForSomeoneElseStep = defineStep({
   id: "filing-for-someone-else",
   title: "Are you filing this form for someone else?",
   fields: [
@@ -67,4 +67,4 @@ export const filingForSomeoneElseStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/social-security/steps/NewNameStep.tsx
+++ b/src/content/forms/social-security/steps/NewNameStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const newNameStep: Step = {
+export const newNameStep = defineStep({
   id: "new-name",
   title: "What is your new name?",
   description: "This is the name that will show on your new card.",
@@ -12,4 +12,4 @@ export const newNameStep: Step = {
       <NameField type="newName" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/social-security/steps/OldNameStep.tsx
+++ b/src/content/forms/social-security/steps/OldNameStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const oldNameStep: Step = {
+export const oldNameStep = defineStep({
   id: "old-name",
   title: "What was your name at birth?",
   description:
@@ -13,4 +13,4 @@ export const oldNameStep: Step = {
       <NameField type="oldName" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/social-security/steps/ParentOneNameStep.tsx
+++ b/src/content/forms/social-security/steps/ParentOneNameStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const parentOneNameStep: Step = {
+export const parentOneNameStep = defineStep({
   id: "parent-one",
   title: "What is your mother's (or first parent's) name?",
   description:
@@ -13,4 +13,4 @@ export const parentOneNameStep: Step = {
       <NameField type="mothersName" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/social-security/steps/ParentTwoNameStep.tsx
+++ b/src/content/forms/social-security/steps/ParentTwoNameStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const parentTwoNameStep: Step = {
+export const parentTwoNameStep = defineStep({
   id: "parent-two",
   title: "What is your father's (or second parent's) name?",
   fields: ["fathersFirstName", "fathersMiddleName", "fathersLastName"],
@@ -11,4 +11,4 @@ export const parentTwoNameStep: Step = {
       <NameField type="fathersName" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/social-security/steps/PhoneNumberStep.tsx
+++ b/src/content/forms/social-security/steps/PhoneNumberStep.tsx
@@ -1,8 +1,8 @@
 import { FormStep } from "../../../../components/forms/FormStep";
 import { PhoneField } from "../../../../components/forms/PhoneField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const phoneNumberStep: Step = {
+export const phoneNumberStep = defineStep({
   id: "phone-number",
   title: "What is your phone number?",
   fields: ["phoneNumber"],
@@ -11,4 +11,4 @@ export const phoneNumberStep: Step = {
       <PhoneField name="phoneNumber" />
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/social-security/steps/PreviousNamesStep.tsx
+++ b/src/content/forms/social-security/steps/PreviousNamesStep.tsx
@@ -5,9 +5,9 @@ import {
 } from "../../../../components/forms/FormStep";
 import { LongTextField } from "../../../../components/forms/LongTextField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const previousNamesStep: Step = {
+export const previousNamesStep = defineStep({
   id: "previous-names",
   title: "Have you used any other legal names?",
   fields: [
@@ -37,4 +37,4 @@ export const previousNamesStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/social-security/steps/PreviousSocialSecurityCardStep.tsx
+++ b/src/content/forms/social-security/steps/PreviousSocialSecurityCardStep.tsx
@@ -5,9 +5,9 @@ import {
 } from "../../../../components/forms/FormStep";
 import { NameField } from "../../../../components/forms/NameField";
 import { YesNoField } from "../../../../components/forms/YesNoField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const previousSocialSecurityCardStep: Step = {
+export const previousSocialSecurityCardStep = defineStep({
   id: "previous-social-security-card",
   title: "Do you have a previous Social Security card?",
   description:
@@ -46,4 +46,4 @@ export const previousSocialSecurityCardStep: Step = {
       </FormStep>
     );
   },
-};
+});

--- a/src/content/forms/social-security/steps/RaceStep.tsx
+++ b/src/content/forms/social-security/steps/RaceStep.tsx
@@ -1,9 +1,9 @@
 import { Banner } from "../../../../components/common/Banner";
 import { CheckboxGroupField } from "../../../../components/forms/CheckboxGroupField";
 import { FormStep } from "../../../../components/forms/FormStep";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const raceStep: Step = {
+export const raceStep = defineStep({
   id: "race",
   title: "What is your race?",
   description: "This response is optional.",
@@ -51,4 +51,4 @@ export const raceStep: Step = {
       </Banner>
     </FormStep>
   ),
-};
+});

--- a/src/content/forms/social-security/steps/SexStep.tsx
+++ b/src/content/forms/social-security/steps/SexStep.tsx
@@ -1,9 +1,9 @@
 import { Banner } from "../../../../components/common/Banner";
 import { FormStep } from "../../../../components/forms/FormStep";
 import { RadioGroupField } from "../../../../components/forms/RadioGroupField";
-import type { Step } from "../../../../forms/types";
+import { defineStep } from "../../../../forms/defineStep";
 
-export const sexStep: Step = {
+export const sexStep = defineStep({
   id: "sex",
   title: "What is your sex?",
   description:
@@ -57,4 +57,4 @@ export const sexStep: Step = {
       </Banner>
     </FormStep>
   ),
-};
+});

--- a/src/forms/defineStep.ts
+++ b/src/forms/defineStep.ts
@@ -1,0 +1,5 @@
+import type { Step } from "./types";
+
+export function defineStep(step: Step): Step {
+  return step;
+}


### PR DESCRIPTION
Rather than each step component importing the `Step` type for an object, create and use a new `defineStep()` function which matches the API used for `defineForm()` and `definePdf()`, for parity.