### PR TITLE
Use subpath imports

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import type { StorybookConfig } from "@storybook/react-vite";
 
 const excludedProps = new Set([
@@ -41,15 +40,6 @@ const config: StorybookConfig = {
       propFilter: (prop) =>
         !prop.name.startsWith("aria-") && !excludedProps.has(prop.name),
     },
-  },
-  viteFinal: async (config) => {
-    if (config.resolve) {
-      config.resolve.alias = {
-        ...config.resolve?.alias,
-        "~": path.resolve(__dirname, "src"),
-      };
-    }
-    return config;
   },
 };
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { StorybookConfig } from "@storybook/react-vite";
 
 const excludedProps = new Set([
@@ -40,6 +41,15 @@ const config: StorybookConfig = {
       propFilter: (prop) =>
         !prop.name.startsWith("aria-") && !excludedProps.has(prop.name),
     },
+  },
+  viteFinal: async (config) => {
+    if (config.resolve) {
+      config.resolve.alias = {
+        ...config.resolve?.alias,
+        "~": path.resolve(__dirname, "src"),
+      };
+    }
+    return config;
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,19 @@
     "pdf:schema": "tsx scripts/extract-pdf-schema.ts",
     "pdf:manage": "vite --config pdf-manager/vite.config.ts --open"
   },
+  "imports": {
+    "#*": [
+      "./src/*",
+      "./src/*.ts",
+      "./src/*.tsx",
+      "./src/*.js",
+      "./src/*.jsx",
+      "./src/*/index.ts",
+      "./src/*/index.tsx",
+      "./src/*/index.js",
+      "./src/*/index.jsx"
+    ]
+  },
   "simple-git-hooks": {
     "pre-commit": "./node_modules/.bin/nano-staged"
   },

--- a/pdf-manager/lib/define.ts
+++ b/pdf-manager/lib/define.ts
@@ -50,7 +50,7 @@ function generateDefinition({
     "pdfPath: pdf,",
   ];
   const fieldLines = pdfFields.map((f) => `  ${escapeKey(f.name)}: undefined,`);
-  return `import { definePdf } from "~/pdfs/definePdf";
+  return `import { definePdf } from "#pdfs/definePdf";
 import pdf from "./${id}.pdf";
 import type { PdfFieldName } from "./schema";
 
@@ -91,8 +91,8 @@ function generateStarterTest({
       : "    // TODO: Add form data for resolver";
 
   return `import { describe, it } from "vitest";
-import type { FormData } from "~/constants/fields";
-import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
+import type { FormData } from "#constants/fields";
+import { expectPdfFieldsMatch } from "#pdfs/expectPdfFieldsMatch";
 import ${importName} from ".";
 
 describe("${escapedTitle}", () => {

--- a/pdf-manager/lib/define.ts
+++ b/pdf-manager/lib/define.ts
@@ -50,7 +50,7 @@ function generateDefinition({
     "pdfPath: pdf,",
   ];
   const fieldLines = pdfFields.map((f) => `  ${escapeKey(f.name)}: undefined,`);
-  return `import { definePdf } from "../../../../pdfs/definePdf";
+  return `import { definePdf } from "~/pdfs/definePdf";
 import pdf from "./${id}.pdf";
 import type { PdfFieldName } from "./schema";
 
@@ -91,8 +91,8 @@ function generateStarterTest({
       : "    // TODO: Add form data for resolver";
 
   return `import { describe, it } from "vitest";
-import type { FormData } from "../../../../constants/fields";
-import { expectPdfFieldsMatch } from "../../../../pdfs/expectPdfFieldsMatch";
+import type { FormData } from "~/constants/fields";
+import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
 import ${importName} from ".";
 
 describe("${escapedTitle}", () => {

--- a/src/components/common/Checkbox/Checkbox.tsx
+++ b/src/components/common/Checkbox/Checkbox.tsx
@@ -9,7 +9,7 @@ import { FieldError } from "../Form";
 
 import "./Checkbox.css";
 import clsx from "clsx";
-import { smartquotes } from "~/utils/smartquotes";
+import { smartquotes } from "#utils/smartquotes";
 
 export interface CheckboxProps extends CheckboxFieldProps {
   label?: string;

--- a/src/components/common/Checkbox/Checkbox.tsx
+++ b/src/components/common/Checkbox/Checkbox.tsx
@@ -9,7 +9,7 @@ import { FieldError } from "../Form";
 
 import "./Checkbox.css";
 import clsx from "clsx";
-import { smartquotes } from "../../../utils/smartquotes";
+import { smartquotes } from "~/utils/smartquotes";
 
 export interface CheckboxProps extends CheckboxFieldProps {
   label?: string;

--- a/src/components/common/YouTube/YouTube.tsx
+++ b/src/components/common/YouTube/YouTube.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import {
   fetchYouTubeVideoDetails,
   type YouTubeOEmbedResponse,
-} from "~/utils/fetchYouTubeVideoDetails";
+} from "#utils/fetchYouTubeVideoDetails";
 
 export interface YouTubeProps {
   url: string;

--- a/src/components/common/YouTube/YouTube.tsx
+++ b/src/components/common/YouTube/YouTube.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import {
   fetchYouTubeVideoDetails,
   type YouTubeOEmbedResponse,
-} from "../../../utils/fetchYouTubeVideoDetails";
+} from "~/utils/fetchYouTubeVideoDetails";
 
 export interface YouTubeProps {
   url: string;

--- a/src/components/forms/AddressField/AddressField.test.tsx
+++ b/src/components/forms/AddressField/AddressField.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
-import { JURISDICTIONS } from "~/constants/jurisdictions";
+import { JURISDICTIONS } from "#constants/jurisdictions";
 import { renderWithFormProvider, screen } from "../test-utils";
 import { AddressField } from "./AddressField";
 

--- a/src/components/forms/AddressField/AddressField.test.tsx
+++ b/src/components/forms/AddressField/AddressField.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
-import { JURISDICTIONS } from "../../../constants/jurisdictions";
+import { JURISDICTIONS } from "~/constants/jurisdictions";
 import { renderWithFormProvider, screen } from "../test-utils";
 import { AddressField } from "./AddressField";
 

--- a/src/components/forms/AddressField/AddressField.tsx
+++ b/src/components/forms/AddressField/AddressField.tsx
@@ -1,8 +1,8 @@
 import { type MaskitoOptions, maskitoTransform } from "@maskito/core";
 import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "../../../constants/fields";
-import { JURISDICTIONS } from "../../../constants/jurisdictions";
+import type { FieldName } from "~/constants/fields";
+import { JURISDICTIONS } from "~/constants/jurisdictions";
 import { ComboBox, ComboBoxItem } from "../../common/ComboBox";
 import { TextField } from "../../common/TextField";
 import "./AddressField.css";

--- a/src/components/forms/AddressField/AddressField.tsx
+++ b/src/components/forms/AddressField/AddressField.tsx
@@ -1,8 +1,8 @@
 import { type MaskitoOptions, maskitoTransform } from "@maskito/core";
 import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "~/constants/fields";
-import { JURISDICTIONS } from "~/constants/jurisdictions";
+import type { FieldName } from "#constants/fields";
+import { JURISDICTIONS } from "#constants/jurisdictions";
 import { ComboBox, ComboBoxItem } from "../../common/ComboBox";
 import { TextField } from "../../common/TextField";
 import "./AddressField.css";

--- a/src/components/forms/CheckboxField/CheckboxField.tsx
+++ b/src/components/forms/CheckboxField/CheckboxField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "../../../constants/fields";
-import { smartquotes } from "../../../utils/smartquotes";
+import type { FieldName } from "~/constants/fields";
+import { smartquotes } from "~/utils/smartquotes";
 import { Checkbox, type CheckboxProps } from "../../common/Checkbox";
 import "./CheckboxField.css";
 

--- a/src/components/forms/CheckboxField/CheckboxField.tsx
+++ b/src/components/forms/CheckboxField/CheckboxField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "~/constants/fields";
-import { smartquotes } from "~/utils/smartquotes";
+import type { FieldName } from "#constants/fields";
+import { smartquotes } from "#utils/smartquotes";
 import { Checkbox, type CheckboxProps } from "../../common/Checkbox";
 import "./CheckboxField.css";
 

--- a/src/components/forms/CheckboxGroupField/CheckboxGroupField.tsx
+++ b/src/components/forms/CheckboxGroupField/CheckboxGroupField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import { type FieldName, PREFER_NOT_TO_ANSWER } from "~/constants/fields";
-import { smartquotes } from "~/utils/smartquotes";
+import { type FieldName, PREFER_NOT_TO_ANSWER } from "#constants/fields";
+import { smartquotes } from "#utils/smartquotes";
 import { Checkbox, type CheckboxProps } from "../../common/Checkbox";
 import {
   CheckboxGroup,

--- a/src/components/forms/CheckboxGroupField/CheckboxGroupField.tsx
+++ b/src/components/forms/CheckboxGroupField/CheckboxGroupField.tsx
@@ -1,9 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import {
-  type FieldName,
-  PREFER_NOT_TO_ANSWER,
-} from "../../../constants/fields";
-import { smartquotes } from "../../../utils/smartquotes";
+import { type FieldName, PREFER_NOT_TO_ANSWER } from "~/constants/fields";
+import { smartquotes } from "~/utils/smartquotes";
 import { Checkbox, type CheckboxProps } from "../../common/Checkbox";
 import {
   CheckboxGroup,

--- a/src/components/forms/ComboBoxField/ComboBoxField.tsx
+++ b/src/components/forms/ComboBoxField/ComboBoxField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "../../../constants/fields";
-import { smartquotes } from "../../../utils/smartquotes";
+import type { FieldName } from "~/constants/fields";
+import { smartquotes } from "~/utils/smartquotes";
 import { ComboBox, ComboBoxItem } from "../../common/ComboBox";
 import "./ComboBoxField.css";
 

--- a/src/components/forms/ComboBoxField/ComboBoxField.tsx
+++ b/src/components/forms/ComboBoxField/ComboBoxField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "~/constants/fields";
-import { smartquotes } from "~/utils/smartquotes";
+import type { FieldName } from "#constants/fields";
+import { smartquotes } from "#utils/smartquotes";
 import { ComboBox, ComboBoxItem } from "../../common/ComboBox";
 import "./ComboBoxField.css";
 

--- a/src/components/forms/CostsTable/CostsTable.test.tsx
+++ b/src/components/forms/CostsTable/CostsTable.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { FormCost } from "../../../constants/forms";
+import type { FormCost } from "~/constants/forms";
 import { CostsTable } from "./CostsTable";
 
 const filingFee: FormCost = {

--- a/src/components/forms/CostsTable/CostsTable.test.tsx
+++ b/src/components/forms/CostsTable/CostsTable.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { FormCost } from "~/constants/forms";
+import type { FormCost } from "#constants/forms";
 import { CostsTable } from "./CostsTable";
 
 const filingFee: FormCost = {

--- a/src/components/forms/CostsTable/CostsTable.tsx
+++ b/src/components/forms/CostsTable/CostsTable.tsx
@@ -1,6 +1,6 @@
-import type { FormCost } from "../../../constants/forms";
-import { formatCurrency } from "../../../utils/formatCurrency";
-import { formatTotalCosts } from "../../../utils/formatTotalCosts";
+import type { FormCost } from "~/constants/forms";
+import { formatCurrency } from "~/utils/formatCurrency";
+import { formatTotalCosts } from "~/utils/formatTotalCosts";
 import "./CostsTable.css";
 
 interface CostsTableProps {

--- a/src/components/forms/CostsTable/CostsTable.tsx
+++ b/src/components/forms/CostsTable/CostsTable.tsx
@@ -1,6 +1,6 @@
-import type { FormCost } from "~/constants/forms";
-import { formatCurrency } from "~/utils/formatCurrency";
-import { formatTotalCosts } from "~/utils/formatTotalCosts";
+import type { FormCost } from "#constants/forms";
+import { formatCurrency } from "#utils/formatCurrency";
+import { formatTotalCosts } from "#utils/formatTotalCosts";
 import "./CostsTable.css";
 
 interface CostsTableProps {

--- a/src/components/forms/DeleteFormDataModal/DeleteFormDataModal.test.tsx
+++ b/src/components/forms/DeleteFormDataModal/DeleteFormDataModal.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { DeleteFormDataModal } from "./DeleteFormDataModal";
 
 // Mock the database module
-vi.mock("~/db/database", () => ({
+vi.mock("#db/database", () => ({
   clearAllFields: vi.fn().mockResolvedValue(undefined),
   getAllFields: vi.fn().mockResolvedValue([
     { field: "firstName", value: "John" },
@@ -32,7 +32,7 @@ describe("DeleteFormDataModal", () => {
   });
 
   it("shows no data message when no responses exist", async () => {
-    const { getAllFields } = await import("~/db/database");
+    const { getAllFields } = await import("#db/database");
     vi.mocked(getAllFields).mockResolvedValueOnce([]);
 
     render(<DeleteFormDataModal />);
@@ -43,7 +43,7 @@ describe("DeleteFormDataModal", () => {
   });
 
   it("hides delete button when no data exists", async () => {
-    const { getAllFields } = await import("~/db/database");
+    const { getAllFields } = await import("#db/database");
     vi.mocked(getAllFields).mockResolvedValueOnce([]);
 
     render(<DeleteFormDataModal />);
@@ -113,7 +113,7 @@ describe("DeleteFormDataModal", () => {
 
   it("calls clearAllFields when delete is clicked", async () => {
     const user = userEvent.setup();
-    const { clearAllFields } = await import("~/db/database");
+    const { clearAllFields } = await import("#db/database");
 
     render(<DeleteFormDataModal />);
 

--- a/src/components/forms/DeleteFormDataModal/DeleteFormDataModal.test.tsx
+++ b/src/components/forms/DeleteFormDataModal/DeleteFormDataModal.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { DeleteFormDataModal } from "./DeleteFormDataModal";
 
 // Mock the database module
-vi.mock("../../../db/database", () => ({
+vi.mock("~/db/database", () => ({
   clearAllFields: vi.fn().mockResolvedValue(undefined),
   getAllFields: vi.fn().mockResolvedValue([
     { field: "firstName", value: "John" },
@@ -32,7 +32,7 @@ describe("DeleteFormDataModal", () => {
   });
 
   it("shows no data message when no responses exist", async () => {
-    const { getAllFields } = await import("../../../db/database");
+    const { getAllFields } = await import("~/db/database");
     vi.mocked(getAllFields).mockResolvedValueOnce([]);
 
     render(<DeleteFormDataModal />);
@@ -43,7 +43,7 @@ describe("DeleteFormDataModal", () => {
   });
 
   it("hides delete button when no data exists", async () => {
-    const { getAllFields } = await import("../../../db/database");
+    const { getAllFields } = await import("~/db/database");
     vi.mocked(getAllFields).mockResolvedValueOnce([]);
 
     render(<DeleteFormDataModal />);
@@ -113,7 +113,7 @@ describe("DeleteFormDataModal", () => {
 
   it("calls clearAllFields when delete is clicked", async () => {
     const user = userEvent.setup();
-    const { clearAllFields } = await import("../../../db/database");
+    const { clearAllFields } = await import("~/db/database");
 
     render(<DeleteFormDataModal />);
 

--- a/src/components/forms/DeleteFormDataModal/DeleteFormDataModal.tsx
+++ b/src/components/forms/DeleteFormDataModal/DeleteFormDataModal.tsx
@@ -1,6 +1,6 @@
 import { RiDeleteBin2Line } from "@remixicon/react";
 import { useEffect, useState } from "react";
-import { clearAllFields, getAllFields } from "~/db/database";
+import { clearAllFields, getAllFields } from "#db/database";
 import { Button } from "../../common/Button";
 import { Heading } from "../../common/Content";
 import { Dialog, DialogTrigger } from "../../common/Dialog";

--- a/src/components/forms/DeleteFormDataModal/DeleteFormDataModal.tsx
+++ b/src/components/forms/DeleteFormDataModal/DeleteFormDataModal.tsx
@@ -1,6 +1,6 @@
 import { RiDeleteBin2Line } from "@remixicon/react";
 import { useEffect, useState } from "react";
-import { clearAllFields, getAllFields } from "../../../db/database";
+import { clearAllFields, getAllFields } from "~/db/database";
 import { Button } from "../../common/Button";
 import { Heading } from "../../common/Content";
 import { Dialog, DialogTrigger } from "../../common/Dialog";

--- a/src/components/forms/EmailField/EmailField.tsx
+++ b/src/components/forms/EmailField/EmailField.tsx
@@ -1,5 +1,5 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "~/constants/fields";
+import type { FieldName } from "#constants/fields";
 import { TextField, type TextFieldProps } from "../../common/TextField";
 import "./EmailField.css";
 

--- a/src/components/forms/EmailField/EmailField.tsx
+++ b/src/components/forms/EmailField/EmailField.tsx
@@ -1,5 +1,5 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "../../../constants/fields";
+import type { FieldName } from "~/constants/fields";
 import { TextField, type TextFieldProps } from "../../common/TextField";
 import "./EmailField.css";
 

--- a/src/components/forms/FormCompleteStep/FormCompleteStep.test.tsx
+++ b/src/components/forms/FormCompleteStep/FormCompleteStep.test.tsx
@@ -6,7 +6,7 @@ import {
   type FormCompleteStepProps,
 } from "./FormCompleteStep";
 
-vi.mock("~/db/database", () => ({
+vi.mock("#db/database", () => ({
   clearFormProgress: vi.fn().mockResolvedValue(undefined),
   getAllFields: vi.fn().mockResolvedValue([]),
 }));
@@ -155,7 +155,7 @@ describe("FormCompleteStep", () => {
       const reloadSpy = vi.fn();
       vi.stubGlobal("location", { reload: reloadSpy });
 
-      const { clearFormProgress } = await import("~/db/database");
+      const { clearFormProgress } = await import("#db/database");
 
       render(<FormCompleteStep {...defaultProps} />);
       await user.click(screen.getByRole("button", { name: /restart/i }));

--- a/src/components/forms/FormCompleteStep/FormCompleteStep.test.tsx
+++ b/src/components/forms/FormCompleteStep/FormCompleteStep.test.tsx
@@ -6,7 +6,7 @@ import {
   type FormCompleteStepProps,
 } from "./FormCompleteStep";
 
-vi.mock("../../../db/database", () => ({
+vi.mock("~/db/database", () => ({
   clearFormProgress: vi.fn().mockResolvedValue(undefined),
   getAllFields: vi.fn().mockResolvedValue([]),
 }));
@@ -155,7 +155,7 @@ describe("FormCompleteStep", () => {
       const reloadSpy = vi.fn();
       vi.stubGlobal("location", { reload: reloadSpy });
 
-      const { clearFormProgress } = await import("../../../db/database");
+      const { clearFormProgress } = await import("~/db/database");
 
       render(<FormCompleteStep {...defaultProps} />);
       await user.click(screen.getByRole("button", { name: /restart/i }));

--- a/src/components/forms/FormCompleteStep/FormCompleteStep.tsx
+++ b/src/components/forms/FormCompleteStep/FormCompleteStep.tsx
@@ -1,12 +1,12 @@
 import { RiDownloadLine, RiRestartLine } from "@remixicon/react";
 import { useEffect, useState } from "react";
-import { clearFormProgress } from "~/db/database";
+import { clearFormProgress } from "#db/database";
 import { Button } from "../../common/Button";
 import { Heading } from "../../common/Content/Content";
 import { DeleteFormDataModal } from "../DeleteFormDataModal";
 import { FormFeedback } from "../FormFeedback/FormFeedback";
 import "./FormCompleteStep.css";
-import type { FormSlug } from "~/constants/forms";
+import type { FormSlug } from "#constants/forms";
 
 export interface FormCompleteStepProps {
   slug: FormSlug;

--- a/src/components/forms/FormCompleteStep/FormCompleteStep.tsx
+++ b/src/components/forms/FormCompleteStep/FormCompleteStep.tsx
@@ -1,12 +1,12 @@
 import { RiDownloadLine, RiRestartLine } from "@remixicon/react";
 import { useEffect, useState } from "react";
-import { clearFormProgress } from "../../../db/database";
+import { clearFormProgress } from "~/db/database";
 import { Button } from "../../common/Button";
 import { Heading } from "../../common/Content/Content";
 import { DeleteFormDataModal } from "../DeleteFormDataModal";
 import { FormFeedback } from "../FormFeedback/FormFeedback";
 import "./FormCompleteStep.css";
-import type { FormSlug } from "../../../constants/forms";
+import type { FormSlug } from "~/constants/forms";
 
 export interface FormCompleteStepProps {
   slug: FormSlug;

--- a/src/components/forms/FormContainer/FormContainer.test.tsx
+++ b/src/components/forms/FormContainer/FormContainer.test.tsx
@@ -1,13 +1,13 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { FormConfig } from "../../../constants/forms";
-import * as db from "../../../db/database";
-import type { Step } from "../../../forms/types";
+import type { FormConfig } from "~/constants/forms";
+import * as db from "~/db/database";
+import type { Step } from "~/forms/types";
 import { FormStep } from "../FormStep/FormStep";
 import { FormContainer } from "./FormContainer";
 
-vi.mock("../../../db/database", () => ({
+vi.mock("~/db/database", () => ({
   getFormProgress: vi.fn().mockResolvedValue(undefined),
   saveFormProgress: vi.fn().mockResolvedValue(undefined),
   clearFormProgress: vi.fn().mockResolvedValue(undefined),
@@ -17,12 +17,12 @@ vi.mock("../../../db/database", () => ({
   deleteField: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("../../../forms/getFormConfig");
-vi.mock("../../../forms/getFormPdfMetadata", () => ({
+vi.mock("~/forms/getFormConfig");
+vi.mock("~/forms/getFormPdfMetadata", () => ({
   getFormPdfMetadata: vi.fn().mockResolvedValue([]),
 }));
 
-import { getFormConfig } from "../../../forms/getFormConfig";
+import { getFormConfig } from "~/forms/getFormConfig";
 
 const plainStep: Step = {
   id: "plain",

--- a/src/components/forms/FormContainer/FormContainer.test.tsx
+++ b/src/components/forms/FormContainer/FormContainer.test.tsx
@@ -1,13 +1,13 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { FormConfig } from "~/constants/forms";
-import * as db from "~/db/database";
-import type { Step } from "~/forms/types";
+import type { FormConfig } from "#constants/forms";
+import * as db from "#db/database";
+import type { Step } from "#forms/types";
 import { FormStep } from "../FormStep/FormStep";
 import { FormContainer } from "./FormContainer";
 
-vi.mock("~/db/database", () => ({
+vi.mock("#db/database", () => ({
   getFormProgress: vi.fn().mockResolvedValue(undefined),
   saveFormProgress: vi.fn().mockResolvedValue(undefined),
   clearFormProgress: vi.fn().mockResolvedValue(undefined),
@@ -17,12 +17,12 @@ vi.mock("~/db/database", () => ({
   deleteField: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("~/forms/getFormConfig");
-vi.mock("~/forms/getFormPdfMetadata", () => ({
+vi.mock("#forms/getFormConfig");
+vi.mock("#forms/getFormPdfMetadata", () => ({
   getFormPdfMetadata: vi.fn().mockResolvedValue([]),
 }));
 
-import { getFormConfig } from "~/forms/getFormConfig";
+import { getFormConfig } from "#forms/getFormConfig";
 
 const plainStep: Step = {
   id: "plain",

--- a/src/components/forms/FormContainer/FormContainer.tsx
+++ b/src/components/forms/FormContainer/FormContainer.tsx
@@ -1,14 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider } from "react-hook-form";
-import type { FormSlug } from "../../../constants/forms";
-import { createFormSubmitHandler } from "../../../forms/createFormSubmitHandler";
-import { getFormConfig } from "../../../forms/getFormConfig";
+import type { FormSlug } from "~/constants/forms";
+import { createFormSubmitHandler } from "~/forms/createFormSubmitHandler";
+import { getFormConfig } from "~/forms/getFormConfig";
 import {
   type FormPdfMetadata,
   getFormPdfMetadata,
-} from "../../../forms/getFormPdfMetadata";
-import { useFormData } from "../../../forms/useFormData";
-import { useFormState } from "../../../forms/useFormState";
+} from "~/forms/getFormPdfMetadata";
+import { useFormData } from "~/forms/useFormData";
+import { useFormState } from "~/forms/useFormState";
 import { ProgressCircle } from "../../common/ProgressCircle";
 import { FormCompleteStep } from "../FormCompleteStep";
 import { FormNavigation } from "../FormNavigation";

--- a/src/components/forms/FormContainer/FormContainer.tsx
+++ b/src/components/forms/FormContainer/FormContainer.tsx
@@ -1,14 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider } from "react-hook-form";
-import type { FormSlug } from "~/constants/forms";
-import { createFormSubmitHandler } from "~/forms/createFormSubmitHandler";
-import { getFormConfig } from "~/forms/getFormConfig";
+import type { FormSlug } from "#constants/forms";
+import { createFormSubmitHandler } from "#forms/createFormSubmitHandler";
+import { getFormConfig } from "#forms/getFormConfig";
 import {
   type FormPdfMetadata,
   getFormPdfMetadata,
-} from "~/forms/getFormPdfMetadata";
-import { useFormData } from "~/forms/useFormData";
-import { useFormState } from "~/forms/useFormState";
+} from "#forms/getFormPdfMetadata";
+import { useFormData } from "#forms/useFormData";
+import { useFormState } from "#forms/useFormState";
 import { ProgressCircle } from "../../common/ProgressCircle";
 import { FormCompleteStep } from "../FormCompleteStep";
 import { FormNavigation } from "../FormNavigation";

--- a/src/components/forms/FormContainer/FormStepContext.tsx
+++ b/src/components/forms/FormContainer/FormStepContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
-import type { FormCost } from "~/constants/forms";
-import type { FormPhase } from "~/forms/types";
+import type { FormCost } from "#constants/forms";
+import type { FormPhase } from "#forms/types";
 
 export interface FormStepContextValue {
   onNext: () => void;

--- a/src/components/forms/FormContainer/FormStepContext.tsx
+++ b/src/components/forms/FormContainer/FormStepContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
-import type { FormCost } from "../../../constants/forms";
-import type { FormPhase } from "../../../forms/types";
+import type { FormCost } from "~/constants/forms";
+import type { FormPhase } from "~/forms/types";
 
 export interface FormStepContextValue {
   onNext: () => void;

--- a/src/components/forms/FormFeedback/FormFeedback.tsx
+++ b/src/components/forms/FormFeedback/FormFeedback.tsx
@@ -9,7 +9,7 @@ import {
   RiThumbUpLine,
 } from "@remixicon/react";
 import { useActionState, useRef } from "react";
-import type { FormFeedbackSentiment, FormSlug } from "../../../constants/forms";
+import type { FormFeedbackSentiment, FormSlug } from "~/constants/forms";
 import { Button } from "../../common/Button";
 import { Form } from "../../common/Form";
 import { Radio, RadioGroup } from "../../common/RadioGroup";

--- a/src/components/forms/FormFeedback/FormFeedback.tsx
+++ b/src/components/forms/FormFeedback/FormFeedback.tsx
@@ -9,7 +9,7 @@ import {
   RiThumbUpLine,
 } from "@remixicon/react";
 import { useActionState, useRef } from "react";
-import type { FormFeedbackSentiment, FormSlug } from "~/constants/forms";
+import type { FormFeedbackSentiment, FormSlug } from "#constants/forms";
 import { Button } from "../../common/Button";
 import { Form } from "../../common/Form";
 import { Radio, RadioGroup } from "../../common/RadioGroup";

--- a/src/components/forms/FormReviewStep/FormReviewStep.stories.tsx
+++ b/src/components/forms/FormReviewStep/FormReviewStep.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from "@storybook/react-vite";
-import type { Step } from "~/forms/types";
+import type { Step } from "#forms/types";
 import { FormStepContext } from "../FormContainer/FormStepContext";
 import { FormReviewStep, type FormReviewStepProps } from "./FormReviewStep";
 

--- a/src/components/forms/FormReviewStep/FormReviewStep.stories.tsx
+++ b/src/components/forms/FormReviewStep/FormReviewStep.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from "@storybook/react-vite";
-import type { Step } from "../../../forms/types";
+import type { Step } from "~/forms/types";
 import { FormStepContext } from "../FormContainer/FormStepContext";
 import { FormReviewStep, type FormReviewStepProps } from "./FormReviewStep";
 

--- a/src/components/forms/FormReviewStep/FormReviewStep.tsx
+++ b/src/components/forms/FormReviewStep/FormReviewStep.tsx
@@ -3,7 +3,7 @@ import { Banner } from "../../common/Banner";
 import { Button } from "../../common/Button";
 import "./FormReviewStep.css";
 import { RiDownloadLine } from "@remixicon/react";
-import type { Step } from "../../../forms/types";
+import type { Step } from "~/forms/types";
 import { useFormStep } from "../FormContainer/FormStepContext";
 import { FormReviewTable } from "../FormReviewTable";
 

--- a/src/components/forms/FormReviewStep/FormReviewStep.tsx
+++ b/src/components/forms/FormReviewStep/FormReviewStep.tsx
@@ -3,7 +3,7 @@ import { Banner } from "../../common/Banner";
 import { Button } from "../../common/Button";
 import "./FormReviewStep.css";
 import { RiDownloadLine } from "@remixicon/react";
-import type { Step } from "~/forms/types";
+import type { Step } from "#forms/types";
 import { useFormStep } from "../FormContainer/FormStepContext";
 import { FormReviewTable } from "../FormReviewTable";
 

--- a/src/components/forms/FormReviewTable/FormReviewTable.test.tsx
+++ b/src/components/forms/FormReviewTable/FormReviewTable.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
-import type { Step } from "~/forms/types";
+import type { Step } from "#forms/types";
 import { FormStepContext } from "../FormContainer/FormStepContext";
 import { FormReviewTable } from "./FormReviewTable";
 

--- a/src/components/forms/FormReviewTable/FormReviewTable.test.tsx
+++ b/src/components/forms/FormReviewTable/FormReviewTable.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
-import type { Step } from "../../../forms/types";
+import type { Step } from "~/forms/types";
 import { FormStepContext } from "../FormContainer/FormStepContext";
 import { FormReviewTable } from "./FormReviewTable";
 

--- a/src/components/forms/FormReviewTable/FormReviewTable.tsx
+++ b/src/components/forms/FormReviewTable/FormReviewTable.tsx
@@ -1,11 +1,11 @@
 import { useFormContext } from "react-hook-form";
-import type { FormData } from "~/constants/fields";
-import { resolveFormVisibility } from "~/forms/formVisibility";
-import type { Step } from "~/forms/types";
-import { formatFieldValue, getFieldLabel } from "~/utils/formatReviewFields";
+import type { FormData } from "#constants/fields";
+import { resolveFormVisibility } from "#forms/formVisibility";
+import type { Step } from "#forms/types";
+import { formatFieldValue, getFieldLabel } from "#utils/formatReviewFields";
 import { useFormStep } from "../FormContainer";
 import "./FormReviewTable.css";
-import { smartquotes } from "~/utils/smartquotes";
+import { smartquotes } from "#utils/smartquotes";
 
 export interface FormReviewTableProps {
   steps: readonly Step[];

--- a/src/components/forms/FormReviewTable/FormReviewTable.tsx
+++ b/src/components/forms/FormReviewTable/FormReviewTable.tsx
@@ -1,14 +1,11 @@
 import { useFormContext } from "react-hook-form";
-import type { FormData } from "../../../constants/fields";
-import { resolveFormVisibility } from "../../../forms/formVisibility";
-import type { Step } from "../../../forms/types";
-import {
-  formatFieldValue,
-  getFieldLabel,
-} from "../../../utils/formatReviewFields";
+import type { FormData } from "~/constants/fields";
+import { resolveFormVisibility } from "~/forms/formVisibility";
+import type { Step } from "~/forms/types";
+import { formatFieldValue, getFieldLabel } from "~/utils/formatReviewFields";
 import { useFormStep } from "../FormContainer";
 import "./FormReviewTable.css";
-import { smartquotes } from "../../../utils/smartquotes";
+import { smartquotes } from "~/utils/smartquotes";
 
 export interface FormReviewTableProps {
   steps: readonly Step[];

--- a/src/components/forms/FormStep/FormStep.test.tsx
+++ b/src/components/forms/FormStep/FormStep.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, renderHook, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
-import type { FormPhase, Step } from "../../../forms/types";
+import type { FormPhase, Step } from "~/forms/types";
 import { FormStepContext } from "../FormContainer/FormStepContext";
 import { FormStep, FormSubsection, useFieldVisible } from "./FormStep";
 

--- a/src/components/forms/FormStep/FormStep.test.tsx
+++ b/src/components/forms/FormStep/FormStep.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, renderHook, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
-import type { FormPhase, Step } from "~/forms/types";
+import type { FormPhase, Step } from "#forms/types";
 import { FormStepContext } from "../FormContainer/FormStepContext";
 import { FormStep, FormSubsection, useFieldVisible } from "./FormStep";
 

--- a/src/components/forms/FormStep/FormStep.tsx
+++ b/src/components/forms/FormStep/FormStep.tsx
@@ -1,15 +1,12 @@
 import { RiArrowRightLine } from "@remixicon/react";
 import { Heading } from "react-aria-components";
 import { useFormContext } from "react-hook-form";
-import type { FieldName, FormData } from "../../../constants/fields";
-import { getFieldWhen } from "../../../forms/formVisibility";
-import {
-  resolveDescription,
-  resolveTitle,
-} from "../../../forms/resolveStepContent";
-import type { Step } from "../../../forms/types";
-import { slugify } from "../../../utils/slugify";
-import { smartquotes } from "../../../utils/smartquotes";
+import type { FieldName, FormData } from "~/constants/fields";
+import { getFieldWhen } from "~/forms/formVisibility";
+import { resolveDescription, resolveTitle } from "~/forms/resolveStepContent";
+import type { Step } from "~/forms/types";
+import { slugify } from "~/utils/slugify";
+import { smartquotes } from "~/utils/smartquotes";
 import { Button } from "../../common/Button";
 import { useFormStep } from "../FormContainer";
 import "./FormStep.css";

--- a/src/components/forms/FormStep/FormStep.tsx
+++ b/src/components/forms/FormStep/FormStep.tsx
@@ -1,12 +1,12 @@
 import { RiArrowRightLine } from "@remixicon/react";
 import { Heading } from "react-aria-components";
 import { useFormContext } from "react-hook-form";
-import type { FieldName, FormData } from "~/constants/fields";
-import { getFieldWhen } from "~/forms/formVisibility";
-import { resolveDescription, resolveTitle } from "~/forms/resolveStepContent";
-import type { Step } from "~/forms/types";
-import { slugify } from "~/utils/slugify";
-import { smartquotes } from "~/utils/smartquotes";
+import type { FieldName, FormData } from "#constants/fields";
+import { getFieldWhen } from "#forms/formVisibility";
+import { resolveDescription, resolveTitle } from "#forms/resolveStepContent";
+import type { Step } from "#forms/types";
+import { slugify } from "#utils/slugify";
+import { smartquotes } from "#utils/smartquotes";
 import { Button } from "../../common/Button";
 import { useFormStep } from "../FormContainer";
 import "./FormStep.css";

--- a/src/components/forms/FormTitleStep/FormTitleStep.tsx
+++ b/src/components/forms/FormTitleStep/FormTitleStep.tsx
@@ -7,11 +7,11 @@ import {
 } from "@remixicon/react";
 import { useEffect, useState } from "react";
 import { type IBrowser, type IDevice, UAParser } from "ua-parser-js";
-import type { FormPdfMetadata } from "~/forms/getFormPdfMetadata";
-import { formatBrowser } from "~/utils/formatBrowser";
-import { formatDevice } from "~/utils/formatDevice";
-import { formatTimeEstimate } from "~/utils/formatTimeEstimate";
-import { smartquotes } from "~/utils/smartquotes";
+import type { FormPdfMetadata } from "#forms/getFormPdfMetadata";
+import { formatBrowser } from "#utils/formatBrowser";
+import { formatDevice } from "#utils/formatDevice";
+import { formatTimeEstimate } from "#utils/formatTimeEstimate";
+import { smartquotes } from "#utils/smartquotes";
 import { Button } from "../../common/Button";
 import { Heading } from "../../common/Content/Content";
 import "./FormTitleStep.css";

--- a/src/components/forms/FormTitleStep/FormTitleStep.tsx
+++ b/src/components/forms/FormTitleStep/FormTitleStep.tsx
@@ -7,11 +7,11 @@ import {
 } from "@remixicon/react";
 import { useEffect, useState } from "react";
 import { type IBrowser, type IDevice, UAParser } from "ua-parser-js";
-import type { FormPdfMetadata } from "../../../forms/getFormPdfMetadata";
-import { formatBrowser } from "../../../utils/formatBrowser";
-import { formatDevice } from "../../../utils/formatDevice";
-import { formatTimeEstimate } from "../../../utils/formatTimeEstimate";
-import { smartquotes } from "../../../utils/smartquotes";
+import type { FormPdfMetadata } from "~/forms/getFormPdfMetadata";
+import { formatBrowser } from "~/utils/formatBrowser";
+import { formatDevice } from "~/utils/formatDevice";
+import { formatTimeEstimate } from "~/utils/formatTimeEstimate";
+import { smartquotes } from "~/utils/smartquotes";
 import { Button } from "../../common/Button";
 import { Heading } from "../../common/Content/Content";
 import "./FormTitleStep.css";

--- a/src/components/forms/LanguageSelectField/LanguageSelectField.tsx
+++ b/src/components/forms/LanguageSelectField/LanguageSelectField.tsx
@@ -1,7 +1,7 @@
 import languageNameMap from "language-name-map/map";
 import { Text } from "react-aria-components";
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "../../../constants/fields";
+import type { FieldName } from "~/constants/fields";
 import { ComboBox, ComboBoxItem } from "../../common/ComboBox";
 import "./LanguageSelectField.css";
 

--- a/src/components/forms/LanguageSelectField/LanguageSelectField.tsx
+++ b/src/components/forms/LanguageSelectField/LanguageSelectField.tsx
@@ -1,7 +1,7 @@
 import languageNameMap from "language-name-map/map";
 import { Text } from "react-aria-components";
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "~/constants/fields";
+import type { FieldName } from "#constants/fields";
 import { ComboBox, ComboBoxItem } from "../../common/ComboBox";
 import "./LanguageSelectField.css";
 

--- a/src/components/forms/LongTextField/LongTextField.tsx
+++ b/src/components/forms/LongTextField/LongTextField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "../../../constants/fields";
-import { smartquotes } from "../../../utils/smartquotes";
+import type { FieldName } from "~/constants/fields";
+import { smartquotes } from "~/utils/smartquotes";
 import { TextArea, type TextAreaProps } from "../../common/TextArea";
 import "./LongTextField.css";
 

--- a/src/components/forms/LongTextField/LongTextField.tsx
+++ b/src/components/forms/LongTextField/LongTextField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "~/constants/fields";
-import { smartquotes } from "~/utils/smartquotes";
+import type { FieldName } from "#constants/fields";
+import { smartquotes } from "#utils/smartquotes";
 import { TextArea, type TextAreaProps } from "../../common/TextArea";
 import "./LongTextField.css";
 

--- a/src/components/forms/MemorableDateField/MemorableDateField.tsx
+++ b/src/components/forms/MemorableDateField/MemorableDateField.tsx
@@ -1,7 +1,7 @@
 import { parseDate } from "@internationalized/date";
 import type { DateValue } from "react-aria-components";
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "~/constants/fields";
+import type { FieldName } from "#constants/fields";
 import { DateField, type DateFieldProps } from "../../common/DateField";
 import "./MemorableDateField.css";
 

--- a/src/components/forms/MemorableDateField/MemorableDateField.tsx
+++ b/src/components/forms/MemorableDateField/MemorableDateField.tsx
@@ -1,7 +1,7 @@
 import { parseDate } from "@internationalized/date";
 import type { DateValue } from "react-aria-components";
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "../../../constants/fields";
+import type { FieldName } from "~/constants/fields";
 import { DateField, type DateFieldProps } from "../../common/DateField";
 import "./MemorableDateField.css";
 

--- a/src/components/forms/NameField/NameField.tsx
+++ b/src/components/forms/NameField/NameField.tsx
@@ -1,4 +1,4 @@
-import type { FieldName } from "../../../constants/fields";
+import type { FieldName } from "~/constants/fields";
 import { ShortTextField } from "../ShortTextField/ShortTextField";
 import "./NameField.css";
 

--- a/src/components/forms/NameField/NameField.tsx
+++ b/src/components/forms/NameField/NameField.tsx
@@ -1,4 +1,4 @@
-import type { FieldName } from "~/constants/fields";
+import type { FieldName } from "#constants/fields";
 import { ShortTextField } from "../ShortTextField/ShortTextField";
 import "./NameField.css";
 

--- a/src/components/forms/NumberField/NumberField.tsx
+++ b/src/components/forms/NumberField/NumberField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "~/constants/fields";
-import { smartquotes } from "~/utils/smartquotes";
+import type { FieldName } from "#constants/fields";
+import { smartquotes } from "#utils/smartquotes";
 import {
   NumberField as AriaNumberField,
   type NumberFieldProps,

--- a/src/components/forms/NumberField/NumberField.tsx
+++ b/src/components/forms/NumberField/NumberField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "../../../constants/fields";
-import { smartquotes } from "../../../utils/smartquotes";
+import type { FieldName } from "~/constants/fields";
+import { smartquotes } from "~/utils/smartquotes";
 import {
   NumberField as AriaNumberField,
   type NumberFieldProps,

--- a/src/components/forms/PhoneField/PhoneField.tsx
+++ b/src/components/forms/PhoneField/PhoneField.tsx
@@ -1,6 +1,6 @@
 import { type MaskitoOptions, maskitoTransform } from "@maskito/core";
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "../../../constants/fields";
+import type { FieldName } from "~/constants/fields";
 import { TextField, type TextFieldProps } from "../../common/TextField";
 import "./PhoneField.css";
 

--- a/src/components/forms/PhoneField/PhoneField.tsx
+++ b/src/components/forms/PhoneField/PhoneField.tsx
@@ -1,6 +1,6 @@
 import { type MaskitoOptions, maskitoTransform } from "@maskito/core";
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "~/constants/fields";
+import type { FieldName } from "#constants/fields";
 import { TextField, type TextFieldProps } from "../../common/TextField";
 import "./PhoneField.css";
 

--- a/src/components/forms/PronounSelectField/PronounSelectField.test.tsx
+++ b/src/components/forms/PronounSelectField/PronounSelectField.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
-import { COMMON_PRONOUNS } from "../../../constants/fields";
+import { COMMON_PRONOUNS } from "~/constants/fields";
 import { renderWithFormProvider, screen } from "../test-utils";
 import { PronounSelectField } from "./PronounSelectField";
 

--- a/src/components/forms/PronounSelectField/PronounSelectField.test.tsx
+++ b/src/components/forms/PronounSelectField/PronounSelectField.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
-import { COMMON_PRONOUNS } from "~/constants/fields";
+import { COMMON_PRONOUNS } from "#constants/fields";
 import { renderWithFormProvider, screen } from "../test-utils";
 import { PronounSelectField } from "./PronounSelectField";
 

--- a/src/components/forms/PronounSelectField/PronounSelectField.tsx
+++ b/src/components/forms/PronounSelectField/PronounSelectField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import { ALL } from "~/constants/all";
-import { COMMON_PRONOUNS } from "~/constants/fields";
+import { ALL } from "#constants/all";
+import { COMMON_PRONOUNS } from "#constants/fields";
 import { Tag, TagGroup } from "../../common/TagGroup";
 import { TextField } from "../../common/TextField";
 import "./PronounSelectField.css";

--- a/src/components/forms/PronounSelectField/PronounSelectField.tsx
+++ b/src/components/forms/PronounSelectField/PronounSelectField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import { ALL } from "../../../constants/all";
-import { COMMON_PRONOUNS } from "../../../constants/fields";
+import { ALL } from "~/constants/all";
+import { COMMON_PRONOUNS } from "~/constants/fields";
 import { Tag, TagGroup } from "../../common/TagGroup";
 import { TextField } from "../../common/TextField";
 import "./PronounSelectField.css";

--- a/src/components/forms/RadioGroupField/RadioGroupField.tsx
+++ b/src/components/forms/RadioGroupField/RadioGroupField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import { type FieldName, PREFER_NOT_TO_ANSWER } from "~/constants/fields";
-import { smartquotes } from "~/utils/smartquotes";
+import { type FieldName, PREFER_NOT_TO_ANSWER } from "#constants/fields";
+import { smartquotes } from "#utils/smartquotes";
 import {
   Radio,
   RadioGroup,

--- a/src/components/forms/RadioGroupField/RadioGroupField.tsx
+++ b/src/components/forms/RadioGroupField/RadioGroupField.tsx
@@ -1,9 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import {
-  type FieldName,
-  PREFER_NOT_TO_ANSWER,
-} from "../../../constants/fields";
-import { smartquotes } from "../../../utils/smartquotes";
+import { type FieldName, PREFER_NOT_TO_ANSWER } from "~/constants/fields";
+import { smartquotes } from "~/utils/smartquotes";
 import {
   Radio,
   RadioGroup,

--- a/src/components/forms/RepeatingEntry/RepeatingEntry.tsx
+++ b/src/components/forms/RepeatingEntry/RepeatingEntry.tsx
@@ -1,7 +1,7 @@
 import { RiAddLine, RiDeleteBinLine } from "@remixicon/react";
 import { useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
-import type { FieldName, FormData } from "../../../constants/fields";
+import type { FieldName, FormData } from "~/constants/fields";
 import { Button } from "../../common/Button";
 import "./RepeatingEntry.css";
 

--- a/src/components/forms/RepeatingEntry/RepeatingEntry.tsx
+++ b/src/components/forms/RepeatingEntry/RepeatingEntry.tsx
@@ -1,7 +1,7 @@
 import { RiAddLine, RiDeleteBinLine } from "@remixicon/react";
 import { useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
-import type { FieldName, FormData } from "~/constants/fields";
+import type { FieldName, FormData } from "#constants/fields";
 import { Button } from "../../common/Button";
 import "./RepeatingEntry.css";
 

--- a/src/components/forms/ShortTextField/ShortTextField.tsx
+++ b/src/components/forms/ShortTextField/ShortTextField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "../../../constants/fields";
-import { smartquotes } from "../../../utils/smartquotes";
+import type { FieldName } from "~/constants/fields";
+import { smartquotes } from "~/utils/smartquotes";
 import { TextField, type TextFieldProps } from "../../common/TextField";
 import "./ShortTextField.css";
 

--- a/src/components/forms/ShortTextField/ShortTextField.tsx
+++ b/src/components/forms/ShortTextField/ShortTextField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { FieldName } from "~/constants/fields";
-import { smartquotes } from "~/utils/smartquotes";
+import type { FieldName } from "#constants/fields";
+import { smartquotes } from "#utils/smartquotes";
 import { TextField, type TextFieldProps } from "../../common/TextField";
 import "./ShortTextField.css";
 

--- a/src/components/forms/YesNoField/YesNoField.tsx
+++ b/src/components/forms/YesNoField/YesNoField.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import { type FieldName, PREFER_NOT_TO_ANSWER } from "~/constants/fields";
-import { smartquotes } from "~/utils/smartquotes";
+import { type FieldName, PREFER_NOT_TO_ANSWER } from "#constants/fields";
+import { smartquotes } from "#utils/smartquotes";
 import {
   Radio,
   RadioGroup,

--- a/src/components/forms/YesNoField/YesNoField.tsx
+++ b/src/components/forms/YesNoField/YesNoField.tsx
@@ -1,9 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
-import {
-  type FieldName,
-  PREFER_NOT_TO_ANSWER,
-} from "../../../constants/fields";
-import { smartquotes } from "../../../utils/smartquotes";
+import { type FieldName, PREFER_NOT_TO_ANSWER } from "~/constants/fields";
+import { smartquotes } from "~/utils/smartquotes";
 import {
   Radio,
   RadioGroup,

--- a/src/content/forms/affidavit-of-indigency-ma/index.ts
+++ b/src/content/forms/affidavit-of-indigency-ma/index.ts
@@ -1,4 +1,4 @@
-import { defineForm } from "../../../forms/defineForm";
+import { defineForm } from "~/forms/defineForm";
 import { addressStep } from "./steps/AddressStep";
 import { currentNameStep } from "./steps/CurrentNameStep";
 import { extraFeesStep } from "./steps/ExtraFeesStep";

--- a/src/content/forms/affidavit-of-indigency-ma/index.ts
+++ b/src/content/forms/affidavit-of-indigency-ma/index.ts
@@ -1,4 +1,4 @@
-import { defineForm } from "~/forms/defineForm";
+import { defineForm } from "#forms/defineForm";
 import { addressStep } from "./steps/AddressStep";
 import { currentNameStep } from "./steps/CurrentNameStep";
 import { extraFeesStep } from "./steps/ExtraFeesStep";

--- a/src/content/forms/affidavit-of-indigency-ma/steps/AddressStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/AddressStep.tsx
@@ -1,11 +1,8 @@
-import { Banner } from "../../../../components/common/Banner";
-import { AddressField } from "../../../../components/forms/AddressField";
-import { CheckboxField } from "../../../../components/forms/CheckboxField";
-import {
-  FormStep,
-  useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { defineStep } from "../../../../forms/defineStep";
+import { Banner } from "~/components/common/Banner";
+import { AddressField } from "~/components/forms/AddressField";
+import { CheckboxField } from "~/components/forms/CheckboxField";
+import { FormStep, useFieldVisible } from "~/components/forms/FormStep";
+import { defineStep } from "~/forms/defineStep";
 
 const whenNotUnhoused = (data: Record<string, unknown>) =>
   data.isCurrentlyUnhoused !== true;

--- a/src/content/forms/affidavit-of-indigency-ma/steps/AddressStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/AddressStep.tsx
@@ -1,8 +1,8 @@
-import { Banner } from "~/components/common/Banner";
-import { AddressField } from "~/components/forms/AddressField";
-import { CheckboxField } from "~/components/forms/CheckboxField";
-import { FormStep, useFieldVisible } from "~/components/forms/FormStep";
-import { defineStep } from "~/forms/defineStep";
+import { Banner } from "#components/common/Banner";
+import { AddressField } from "#components/forms/AddressField";
+import { CheckboxField } from "#components/forms/CheckboxField";
+import { FormStep, useFieldVisible } from "#components/forms/FormStep";
+import { defineStep } from "#forms/defineStep";
 
 const whenNotUnhoused = (data: Record<string, unknown>) =>
   data.isCurrentlyUnhoused !== true;

--- a/src/content/forms/affidavit-of-indigency-ma/steps/CurrentNameStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/CurrentNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { defineStep } from "~/forms/defineStep";
 
 export const currentNameStep = defineStep({
   id: "current-name",

--- a/src/content/forms/affidavit-of-indigency-ma/steps/CurrentNameStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/CurrentNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { defineStep } from "#forms/defineStep";
 
 export const currentNameStep = defineStep({
   id: "current-name",

--- a/src/content/forms/affidavit-of-indigency-ma/steps/ExtraFeesStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/ExtraFeesStep.tsx
@@ -1,12 +1,9 @@
 import { useFormContext } from "react-hook-form";
-import { CheckboxField } from "../../../../components/forms/CheckboxField";
-import {
-  FormStep,
-  FormSubsection,
-} from "../../../../components/forms/FormStep";
-import { NumberField } from "../../../../components/forms/NumberField";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { defineStep } from "../../../../forms/defineStep";
+import { CheckboxField } from "~/components/forms/CheckboxField";
+import { FormStep, FormSubsection } from "~/components/forms/FormStep";
+import { NumberField } from "~/components/forms/NumberField";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { defineStep } from "~/forms/defineStep";
 
 const amountProps = {
   label: "Amount (if known)",

--- a/src/content/forms/affidavit-of-indigency-ma/steps/ExtraFeesStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/ExtraFeesStep.tsx
@@ -1,9 +1,9 @@
 import { useFormContext } from "react-hook-form";
-import { CheckboxField } from "~/components/forms/CheckboxField";
-import { FormStep, FormSubsection } from "~/components/forms/FormStep";
-import { NumberField } from "~/components/forms/NumberField";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { defineStep } from "~/forms/defineStep";
+import { CheckboxField } from "#components/forms/CheckboxField";
+import { FormStep, FormSubsection } from "#components/forms/FormStep";
+import { NumberField } from "#components/forms/NumberField";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { defineStep } from "#forms/defineStep";
 
 const amountProps = {
   label: "Amount (if known)",

--- a/src/content/forms/affidavit-of-indigency-ma/steps/IncomePovertyStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/IncomePovertyStep.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
-import { Banner } from "../../../../components/common/Banner";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { NumberField } from "../../../../components/forms/NumberField";
-import { RadioGroupField } from "../../../../components/forms/RadioGroupField";
-import { defineStep } from "../../../../forms/defineStep";
-import type { PovertyGuideline } from "../../../../utils/fetchPovertyGuideline";
-import { fetchPovertyGuideline } from "../../../../utils/fetchPovertyGuideline";
+import { Banner } from "~/components/common/Banner";
+import { FormStep } from "~/components/forms/FormStep";
+import { NumberField } from "~/components/forms/NumberField";
+import { RadioGroupField } from "~/components/forms/RadioGroupField";
+import { defineStep } from "~/forms/defineStep";
+import type { PovertyGuideline } from "~/utils/fetchPovertyGuideline";
+import { fetchPovertyGuideline } from "~/utils/fetchPovertyGuideline";
 import "./IncomePovertyStep.css";
 
 export const INCOME_MULTIPLIERS: Record<string, number> = {

--- a/src/content/forms/affidavit-of-indigency-ma/steps/IncomePovertyStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/IncomePovertyStep.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
-import { Banner } from "~/components/common/Banner";
-import { FormStep } from "~/components/forms/FormStep";
-import { NumberField } from "~/components/forms/NumberField";
-import { RadioGroupField } from "~/components/forms/RadioGroupField";
-import { defineStep } from "~/forms/defineStep";
-import type { PovertyGuideline } from "~/utils/fetchPovertyGuideline";
-import { fetchPovertyGuideline } from "~/utils/fetchPovertyGuideline";
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { NumberField } from "#components/forms/NumberField";
+import { RadioGroupField } from "#components/forms/RadioGroupField";
+import { defineStep } from "#forms/defineStep";
+import type { PovertyGuideline } from "#utils/fetchPovertyGuideline";
+import { fetchPovertyGuideline } from "#utils/fetchPovertyGuideline";
 import "./IncomePovertyStep.css";
 
 export const INCOME_MULTIPLIERS: Record<string, number> = {

--- a/src/content/forms/affidavit-of-indigency-ma/steps/IndigencyBasisStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/IndigencyBasisStep.tsx
@@ -1,8 +1,8 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "~/components/common/Banner";
-import { FormStep } from "~/components/forms/FormStep";
-import { RadioGroupField } from "~/components/forms/RadioGroupField";
-import { defineStep } from "~/forms/defineStep";
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { RadioGroupField } from "#components/forms/RadioGroupField";
+import { defineStep } from "#forms/defineStep";
 
 export const indigencyBasisStep = defineStep({
   id: "indigency-basis",

--- a/src/content/forms/affidavit-of-indigency-ma/steps/IndigencyBasisStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/IndigencyBasisStep.tsx
@@ -1,8 +1,8 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "../../../../components/common/Banner";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { RadioGroupField } from "../../../../components/forms/RadioGroupField";
-import { defineStep } from "../../../../forms/defineStep";
+import { Banner } from "~/components/common/Banner";
+import { FormStep } from "~/components/forms/FormStep";
+import { RadioGroupField } from "~/components/forms/RadioGroupField";
+import { defineStep } from "~/forms/defineStep";
 
 export const indigencyBasisStep = defineStep({
   id: "indigency-basis",

--- a/src/content/forms/affidavit-of-indigency-ma/steps/NormalFeesStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/NormalFeesStep.tsx
@@ -1,14 +1,11 @@
 import { useFormContext } from "react-hook-form";
-import { CheckboxField } from "../../../../components/forms/CheckboxField";
-import { CostsTable } from "../../../../components/forms/CostsTable";
-import { useFormStep } from "../../../../components/forms/FormContainer";
-import {
-  FormStep,
-  FormSubsection,
-} from "../../../../components/forms/FormStep";
-import { NumberField } from "../../../../components/forms/NumberField";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { defineStep } from "../../../../forms/defineStep";
+import { CheckboxField } from "~/components/forms/CheckboxField";
+import { CostsTable } from "~/components/forms/CostsTable";
+import { useFormStep } from "~/components/forms/FormContainer";
+import { FormStep, FormSubsection } from "~/components/forms/FormStep";
+import { NumberField } from "~/components/forms/NumberField";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { defineStep } from "~/forms/defineStep";
 
 const amountProps = {
   label: "Amount (if known)",

--- a/src/content/forms/affidavit-of-indigency-ma/steps/NormalFeesStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/NormalFeesStep.tsx
@@ -1,11 +1,11 @@
 import { useFormContext } from "react-hook-form";
-import { CheckboxField } from "~/components/forms/CheckboxField";
-import { CostsTable } from "~/components/forms/CostsTable";
-import { useFormStep } from "~/components/forms/FormContainer";
-import { FormStep, FormSubsection } from "~/components/forms/FormStep";
-import { NumberField } from "~/components/forms/NumberField";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { defineStep } from "~/forms/defineStep";
+import { CheckboxField } from "#components/forms/CheckboxField";
+import { CostsTable } from "#components/forms/CostsTable";
+import { useFormStep } from "#components/forms/FormContainer";
+import { FormStep, FormSubsection } from "#components/forms/FormStep";
+import { NumberField } from "#components/forms/NumberField";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { defineStep } from "#forms/defineStep";
 
 const amountProps = {
   label: "Amount (if known)",

--- a/src/content/forms/affidavit-of-indigency-ma/steps/PublicAssistanceStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/PublicAssistanceStep.tsx
@@ -1,6 +1,6 @@
-import { CheckboxField } from "~/components/forms/CheckboxField";
-import { FormStep } from "~/components/forms/FormStep";
-import { defineStep } from "~/forms/defineStep";
+import { CheckboxField } from "#components/forms/CheckboxField";
+import { FormStep } from "#components/forms/FormStep";
+import { defineStep } from "#forms/defineStep";
 
 export const publicAssistanceStep = defineStep({
   id: "public-assistance",

--- a/src/content/forms/affidavit-of-indigency-ma/steps/PublicAssistanceStep.tsx
+++ b/src/content/forms/affidavit-of-indigency-ma/steps/PublicAssistanceStep.tsx
@@ -1,6 +1,6 @@
-import { CheckboxField } from "../../../../components/forms/CheckboxField";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { defineStep } from "../../../../forms/defineStep";
+import { CheckboxField } from "~/components/forms/CheckboxField";
+import { FormStep } from "~/components/forms/FormStep";
+import { defineStep } from "~/forms/defineStep";
 
 export const publicAssistanceStep = defineStep({
   id: "public-assistance",

--- a/src/content/forms/court-order-ma-minor/index.ts
+++ b/src/content/forms/court-order-ma-minor/index.ts
@@ -1,5 +1,5 @@
-import { defineForm } from "../../../forms/defineForm";
-import { deriveCurrentAge } from "../../../utils/deriveCurrentAge";
+import { defineForm } from "~/forms/defineForm";
+import { deriveCurrentAge } from "~/utils/deriveCurrentAge";
 import { addressStep } from "./steps/AddressStep";
 import { birthCertificateParentsStep } from "./steps/BirthCerticiateParentsStep";
 import { birthplaceStep } from "./steps/BirthplaceStep";

--- a/src/content/forms/court-order-ma-minor/index.ts
+++ b/src/content/forms/court-order-ma-minor/index.ts
@@ -1,5 +1,5 @@
-import { defineForm } from "~/forms/defineForm";
-import { deriveCurrentAge } from "~/utils/deriveCurrentAge";
+import { defineForm } from "#forms/defineForm";
+import { deriveCurrentAge } from "#utils/deriveCurrentAge";
 import { addressStep } from "./steps/AddressStep";
 import { birthCertificateParentsStep } from "./steps/BirthCerticiateParentsStep";
 import { birthplaceStep } from "./steps/BirthplaceStep";

--- a/src/content/forms/court-order-ma-minor/steps/AddressStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/AddressStep.tsx
@@ -1,7 +1,7 @@
-import { AddressField } from "~/components/forms/AddressField";
-import { FormStep } from "~/components/forms/FormStep";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
+import { AddressField } from "#components/forms/AddressField";
+import { FormStep } from "#components/forms/FormStep";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
 
 export const addressStep = defineStep({
   id: "address",

--- a/src/content/forms/court-order-ma-minor/steps/AddressStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/AddressStep.tsx
@@ -1,7 +1,7 @@
-import { AddressField } from "../../../../components/forms/AddressField";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
+import { AddressField } from "~/components/forms/AddressField";
+import { FormStep } from "~/components/forms/FormStep";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
 
 export const addressStep = defineStep({
   id: "address",

--- a/src/content/forms/court-order-ma-minor/steps/BirthCerticiateParentsStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/BirthCerticiateParentsStep.tsx
@@ -1,7 +1,7 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
+import { FormStep } from "~/components/forms/FormStep";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
 
 export const birthCertificateParentsStep = defineStep({
   id: "birth-certificate-parents",

--- a/src/content/forms/court-order-ma-minor/steps/BirthCerticiateParentsStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/BirthCerticiateParentsStep.tsx
@@ -1,7 +1,7 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
+import { FormStep } from "#components/forms/FormStep";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
 
 export const birthCertificateParentsStep = defineStep({
   id: "birth-certificate-parents",

--- a/src/content/forms/court-order-ma-minor/steps/BirthplaceStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/BirthplaceStep.tsx
@@ -1,10 +1,10 @@
-import { ComboBoxField } from "~/components/forms/ComboBoxField";
-import { FormStep, useFieldVisible } from "~/components/forms/FormStep";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { COUNTRIES } from "~/constants/countries";
-import { JURISDICTIONS } from "~/constants/jurisdictions";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
+import { ComboBoxField } from "#components/forms/ComboBoxField";
+import { FormStep, useFieldVisible } from "#components/forms/FormStep";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { COUNTRIES } from "#constants/countries";
+import { JURISDICTIONS } from "#constants/jurisdictions";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
 
 export const birthplaceStep = defineStep({
   id: "birthplace",

--- a/src/content/forms/court-order-ma-minor/steps/BirthplaceStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/BirthplaceStep.tsx
@@ -1,13 +1,10 @@
-import { ComboBoxField } from "../../../../components/forms/ComboBoxField";
-import {
-  FormStep,
-  useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { COUNTRIES } from "../../../../constants/countries";
-import { JURISDICTIONS } from "../../../../constants/jurisdictions";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
+import { ComboBoxField } from "~/components/forms/ComboBoxField";
+import { FormStep, useFieldVisible } from "~/components/forms/FormStep";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { COUNTRIES } from "~/constants/countries";
+import { JURISDICTIONS } from "~/constants/jurisdictions";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
 
 export const birthplaceStep = defineStep({
   id: "birthplace",

--- a/src/content/forms/court-order-ma-minor/steps/CoGuardianStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/CoGuardianStep.tsx
@@ -1,17 +1,17 @@
 import { Controller, useFormContext } from "react-hook-form";
-import { ComboBox, ComboBoxItem } from "~/components/common/ComboBox";
-import { EmailField } from "~/components/forms/EmailField";
+import { ComboBox, ComboBoxItem } from "#components/common/ComboBox";
+import { EmailField } from "#components/forms/EmailField";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { PhoneField } from "~/components/forms/PhoneField";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { JURISDICTIONS } from "~/constants/jurisdictions";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
+} from "#components/forms/FormStep";
+import { PhoneField } from "#components/forms/PhoneField";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { JURISDICTIONS } from "#constants/jurisdictions";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
 
 export const coGuardianStep = defineStep({
   id: "co-guardian",

--- a/src/content/forms/court-order-ma-minor/steps/CoGuardianStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/CoGuardianStep.tsx
@@ -1,17 +1,17 @@
 import { Controller, useFormContext } from "react-hook-form";
-import { ComboBox, ComboBoxItem } from "../../../../components/common/ComboBox";
-import { EmailField } from "../../../../components/forms/EmailField";
+import { ComboBox, ComboBoxItem } from "~/components/common/ComboBox";
+import { EmailField } from "~/components/forms/EmailField";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { PhoneField } from "../../../../components/forms/PhoneField";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { JURISDICTIONS } from "../../../../constants/jurisdictions";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
+} from "~/components/forms/FormStep";
+import { PhoneField } from "~/components/forms/PhoneField";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { JURISDICTIONS } from "~/constants/jurisdictions";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
 
 export const coGuardianStep = defineStep({
   id: "co-guardian",

--- a/src/content/forms/court-order-ma-minor/steps/ConsentStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ConsentStep.tsx
@@ -2,10 +2,10 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { LongTextField } from "~/components/forms/LongTextField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+} from "#components/forms/FormStep";
+import { LongTextField } from "#components/forms/LongTextField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const consentStep = defineStep({
   id: "consent",

--- a/src/content/forms/court-order-ma-minor/steps/ConsentStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ConsentStep.tsx
@@ -2,10 +2,10 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { LongTextField } from "../../../../components/forms/LongTextField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+} from "~/components/forms/FormStep";
+import { LongTextField } from "~/components/forms/LongTextField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const consentStep = defineStep({
   id: "consent",

--- a/src/content/forms/court-order-ma-minor/steps/CurrentNameStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/CurrentNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { defineStep } from "~/forms/defineStep";
 
 export const currentNameStep = defineStep({
   id: "current-name",

--- a/src/content/forms/court-order-ma-minor/steps/CurrentNameStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/CurrentNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { defineStep } from "#forms/defineStep";
 
 export const currentNameStep = defineStep({
   id: "current-name",

--- a/src/content/forms/court-order-ma-minor/steps/DateOfBirthStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/DateOfBirthStep.tsx
@@ -1,10 +1,10 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "~/components/common/Banner";
-import { FormStep } from "~/components/forms/FormStep";
-import { MemorableDateField } from "~/components/forms/MemorableDateField";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
-import { deriveCurrentAge } from "~/utils/deriveCurrentAge";
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { MemorableDateField } from "#components/forms/MemorableDateField";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
+import { deriveCurrentAge } from "#utils/deriveCurrentAge";
 
 export const dateOfBirthStep = defineStep({
   id: "date-of-birth",

--- a/src/content/forms/court-order-ma-minor/steps/DateOfBirthStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/DateOfBirthStep.tsx
@@ -1,10 +1,10 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "../../../../components/common/Banner";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { MemorableDateField } from "../../../../components/forms/MemorableDateField";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
-import { deriveCurrentAge } from "../../../../utils/deriveCurrentAge";
+import { Banner } from "~/components/common/Banner";
+import { FormStep } from "~/components/forms/FormStep";
+import { MemorableDateField } from "~/components/forms/MemorableDateField";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
+import { deriveCurrentAge } from "~/utils/deriveCurrentAge";
 
 export const dateOfBirthStep = defineStep({
   id: "date-of-birth",

--- a/src/content/forms/court-order-ma-minor/steps/GuardianStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/GuardianStep.tsx
@@ -1,17 +1,17 @@
 import { Controller, useFormContext } from "react-hook-form";
-import { ComboBox, ComboBoxItem } from "~/components/common/ComboBox";
-import { EmailField } from "~/components/forms/EmailField";
+import { ComboBox, ComboBoxItem } from "#components/common/ComboBox";
+import { EmailField } from "#components/forms/EmailField";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { PhoneField } from "~/components/forms/PhoneField";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { JURISDICTIONS } from "~/constants/jurisdictions";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
+} from "#components/forms/FormStep";
+import { PhoneField } from "#components/forms/PhoneField";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { JURISDICTIONS } from "#constants/jurisdictions";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
 
 export const guardianStep = defineStep({
   id: "guardian",

--- a/src/content/forms/court-order-ma-minor/steps/GuardianStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/GuardianStep.tsx
@@ -1,17 +1,17 @@
 import { Controller, useFormContext } from "react-hook-form";
-import { ComboBox, ComboBoxItem } from "../../../../components/common/ComboBox";
-import { EmailField } from "../../../../components/forms/EmailField";
+import { ComboBox, ComboBoxItem } from "~/components/common/ComboBox";
+import { EmailField } from "~/components/forms/EmailField";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { PhoneField } from "../../../../components/forms/PhoneField";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { JURISDICTIONS } from "../../../../constants/jurisdictions";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
+} from "~/components/forms/FormStep";
+import { PhoneField } from "~/components/forms/PhoneField";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { JURISDICTIONS } from "~/constants/jurisdictions";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
 
 export const guardianStep = defineStep({
   id: "guardian",

--- a/src/content/forms/court-order-ma-minor/steps/InterpreterStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/InterpreterStep.tsx
@@ -1,11 +1,11 @@
-import { CheckboxField } from "~/components/forms/CheckboxField";
+import { CheckboxField } from "#components/forms/CheckboxField";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { LanguageSelectField } from "~/components/forms/LanguageSelectField";
-import { defineStep } from "~/forms/defineStep";
+} from "#components/forms/FormStep";
+import { LanguageSelectField } from "#components/forms/LanguageSelectField";
+import { defineStep } from "#forms/defineStep";
 
 export const interpreterStep = defineStep({
   id: "interpreter",

--- a/src/content/forms/court-order-ma-minor/steps/InterpreterStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/InterpreterStep.tsx
@@ -1,11 +1,11 @@
-import { CheckboxField } from "../../../../components/forms/CheckboxField";
+import { CheckboxField } from "~/components/forms/CheckboxField";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { LanguageSelectField } from "../../../../components/forms/LanguageSelectField";
-import { defineStep } from "../../../../forms/defineStep";
+} from "~/components/forms/FormStep";
+import { LanguageSelectField } from "~/components/forms/LanguageSelectField";
+import { defineStep } from "~/forms/defineStep";
 
 export const interpreterStep = defineStep({
   id: "interpreter",

--- a/src/content/forms/court-order-ma-minor/steps/NewNameStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/NewNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { defineStep } from "~/forms/defineStep";
 
 export const newNameStep = defineStep({
   id: "new-name",

--- a/src/content/forms/court-order-ma-minor/steps/NewNameStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/NewNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { defineStep } from "#forms/defineStep";
 
 export const newNameStep = defineStep({
   id: "new-name",

--- a/src/content/forms/court-order-ma-minor/steps/ParentAddressStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ParentAddressStep.tsx
@@ -1,14 +1,14 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "~/components/common/Banner";
-import { AddressField } from "~/components/forms/AddressField";
-import { CheckboxField } from "~/components/forms/CheckboxField";
+import { Banner } from "#components/common/Banner";
+import { AddressField } from "#components/forms/AddressField";
+import { CheckboxField } from "#components/forms/CheckboxField";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
+} from "#components/forms/FormStep";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
 
 export const parentAddressStep = defineStep({
   id: "parent-address",

--- a/src/content/forms/court-order-ma-minor/steps/ParentAddressStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ParentAddressStep.tsx
@@ -1,14 +1,14 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "../../../../components/common/Banner";
-import { AddressField } from "../../../../components/forms/AddressField";
-import { CheckboxField } from "../../../../components/forms/CheckboxField";
+import { Banner } from "~/components/common/Banner";
+import { AddressField } from "~/components/forms/AddressField";
+import { CheckboxField } from "~/components/forms/CheckboxField";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
+} from "~/components/forms/FormStep";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
 
 export const parentAddressStep = defineStep({
   id: "parent-address",

--- a/src/content/forms/court-order-ma-minor/steps/ParentInfoStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ParentInfoStep.tsx
@@ -1,12 +1,9 @@
-import { EmailField } from "../../../../components/forms/EmailField";
-import {
-  FormStep,
-  FormSubsection,
-} from "../../../../components/forms/FormStep";
-import { PhoneField } from "../../../../components/forms/PhoneField";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
+import { EmailField } from "~/components/forms/EmailField";
+import { FormStep, FormSubsection } from "~/components/forms/FormStep";
+import { PhoneField } from "~/components/forms/PhoneField";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
 
 export const parentInfoStep = defineStep({
   id: "parent-info",

--- a/src/content/forms/court-order-ma-minor/steps/ParentInfoStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ParentInfoStep.tsx
@@ -1,9 +1,9 @@
-import { EmailField } from "~/components/forms/EmailField";
-import { FormStep, FormSubsection } from "~/components/forms/FormStep";
-import { PhoneField } from "~/components/forms/PhoneField";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
+import { EmailField } from "#components/forms/EmailField";
+import { FormStep, FormSubsection } from "#components/forms/FormStep";
+import { PhoneField } from "#components/forms/PhoneField";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
 
 export const parentInfoStep = defineStep({
   id: "parent-info",

--- a/src/content/forms/court-order-ma-minor/steps/ParentalRightsTerminatedStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ParentalRightsTerminatedStep.tsx
@@ -1,8 +1,8 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "../../../../components/common/Banner";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+import { Banner } from "~/components/common/Banner";
+import { FormStep } from "~/components/forms/FormStep";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const parentalRightsTerminatedStep = defineStep({
   id: "parental-rights-terminated",

--- a/src/content/forms/court-order-ma-minor/steps/ParentalRightsTerminatedStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ParentalRightsTerminatedStep.tsx
@@ -1,8 +1,8 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "~/components/common/Banner";
-import { FormStep } from "~/components/forms/FormStep";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const parentalRightsTerminatedStep = defineStep({
   id: "parental-rights-terminated",

--- a/src/content/forms/court-order-ma-minor/steps/ParentsDeceasedStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ParentsDeceasedStep.tsx
@@ -1,9 +1,9 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "../../../../components/common/Banner";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
+import { Banner } from "~/components/common/Banner";
+import { FormStep } from "~/components/forms/FormStep";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
 
 export const parentsDeceasedStep = defineStep({
   id: "parent-deceased",

--- a/src/content/forms/court-order-ma-minor/steps/ParentsDeceasedStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ParentsDeceasedStep.tsx
@@ -1,9 +1,9 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "~/components/common/Banner";
-import { FormStep } from "~/components/forms/FormStep";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
 
 export const parentsDeceasedStep = defineStep({
   id: "parent-deceased",

--- a/src/content/forms/court-order-ma-minor/steps/PresentedByStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/PresentedByStep.tsx
@@ -1,6 +1,6 @@
-import { CheckboxField } from "../../../../components/forms/CheckboxField";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { defineStep } from "../../../../forms/defineStep";
+import { CheckboxField } from "~/components/forms/CheckboxField";
+import { FormStep } from "~/components/forms/FormStep";
+import { defineStep } from "~/forms/defineStep";
 
 export const presentedByStep = defineStep({
   id: "presented-by",

--- a/src/content/forms/court-order-ma-minor/steps/PresentedByStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/PresentedByStep.tsx
@@ -1,6 +1,6 @@
-import { CheckboxField } from "~/components/forms/CheckboxField";
-import { FormStep } from "~/components/forms/FormStep";
-import { defineStep } from "~/forms/defineStep";
+import { CheckboxField } from "#components/forms/CheckboxField";
+import { FormStep } from "#components/forms/FormStep";
+import { defineStep } from "#forms/defineStep";
 
 export const presentedByStep = defineStep({
   id: "presented-by",

--- a/src/content/forms/court-order-ma-minor/steps/PreviousNameChangeStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/PreviousNameChangeStep.tsx
@@ -2,12 +2,12 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { LongTextField } from "~/components/forms/LongTextField";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
+} from "#components/forms/FormStep";
+import { LongTextField } from "#components/forms/LongTextField";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
 
 export const previousNameChangeStep = defineStep({
   id: "previous-name-change",

--- a/src/content/forms/court-order-ma-minor/steps/PreviousNameChangeStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/PreviousNameChangeStep.tsx
@@ -2,12 +2,12 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { LongTextField } from "../../../../components/forms/LongTextField";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
+} from "~/components/forms/FormStep";
+import { LongTextField } from "~/components/forms/LongTextField";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
 
 export const previousNameChangeStep = defineStep({
   id: "previous-name-change",

--- a/src/content/forms/court-order-ma-minor/steps/PronounsStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/PronounsStep.tsx
@@ -2,11 +2,11 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { PronounSelectField } from "~/components/forms/PronounSelectField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
+} from "#components/forms/FormStep";
+import { PronounSelectField } from "#components/forms/PronounSelectField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
 
 export const pronounsStep = defineStep({
   id: "pronouns",

--- a/src/content/forms/court-order-ma-minor/steps/PronounsStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/PronounsStep.tsx
@@ -2,11 +2,11 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { PronounSelectField } from "../../../../components/forms/PronounSelectField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
+} from "~/components/forms/FormStep";
+import { PronounSelectField } from "~/components/forms/PronounSelectField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
 
 export const pronounsStep = defineStep({
   id: "pronouns",

--- a/src/content/forms/court-order-ma-minor/steps/ReasonStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ReasonStep.tsx
@@ -1,8 +1,8 @@
-import { Banner } from "../../../../components/common/Banner";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { LongTextField } from "../../../../components/forms/LongTextField";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
+import { Banner } from "~/components/common/Banner";
+import { FormStep } from "~/components/forms/FormStep";
+import { LongTextField } from "~/components/forms/LongTextField";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
 
 export const reasonStep = defineStep({
   id: "reason",

--- a/src/content/forms/court-order-ma-minor/steps/ReasonStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/ReasonStep.tsx
@@ -1,8 +1,8 @@
-import { Banner } from "~/components/common/Banner";
-import { FormStep } from "~/components/forms/FormStep";
-import { LongTextField } from "~/components/forms/LongTextField";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { LongTextField } from "#components/forms/LongTextField";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
 
 export const reasonStep = defineStep({
   id: "reason",

--- a/src/content/forms/court-order-ma-minor/steps/YouthServicesStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/YouthServicesStep.tsx
@@ -1,7 +1,7 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
-import { nameOrFallback } from "../../../../forms/resolveStepContent";
+import { FormStep } from "~/components/forms/FormStep";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
+import { nameOrFallback } from "~/forms/resolveStepContent";
 
 export const youthServicesStep = defineStep({
   id: "youth-services",

--- a/src/content/forms/court-order-ma-minor/steps/YouthServicesStep.tsx
+++ b/src/content/forms/court-order-ma-minor/steps/YouthServicesStep.tsx
@@ -1,7 +1,7 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
-import { nameOrFallback } from "~/forms/resolveStepContent";
+import { FormStep } from "#components/forms/FormStep";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
+import { nameOrFallback } from "#forms/resolveStepContent";
 
 export const youthServicesStep = defineStep({
   id: "youth-services",

--- a/src/content/forms/court-order-ma/index.ts
+++ b/src/content/forms/court-order-ma/index.ts
@@ -1,4 +1,4 @@
-import { defineForm } from "~/forms/defineForm";
+import { defineForm } from "#forms/defineForm";
 import { addressStep } from "./steps/AddressStep";
 import { birthplaceStep } from "./steps/BirthplaceStep";
 import { contactInfoStep } from "./steps/ContactInfoStep";

--- a/src/content/forms/court-order-ma/index.ts
+++ b/src/content/forms/court-order-ma/index.ts
@@ -1,4 +1,4 @@
-import { defineForm } from "../../../forms/defineForm";
+import { defineForm } from "~/forms/defineForm";
 import { addressStep } from "./steps/AddressStep";
 import { birthplaceStep } from "./steps/BirthplaceStep";
 import { contactInfoStep } from "./steps/ContactInfoStep";

--- a/src/content/forms/court-order-ma/steps/AddressStep.tsx
+++ b/src/content/forms/court-order-ma/steps/AddressStep.tsx
@@ -1,12 +1,12 @@
-import { Banner } from "../../../../components/common/Banner";
-import { AddressField } from "../../../../components/forms/AddressField";
-import { CheckboxField } from "../../../../components/forms/CheckboxField";
+import { Banner } from "~/components/common/Banner";
+import { AddressField } from "~/components/forms/AddressField";
+import { CheckboxField } from "~/components/forms/CheckboxField";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { defineStep } from "../../../../forms/defineStep";
+} from "~/components/forms/FormStep";
+import { defineStep } from "~/forms/defineStep";
 
 const whenNotUnhoused = (data: Record<string, unknown>) =>
   data.isCurrentlyUnhoused !== true;

--- a/src/content/forms/court-order-ma/steps/AddressStep.tsx
+++ b/src/content/forms/court-order-ma/steps/AddressStep.tsx
@@ -1,12 +1,12 @@
-import { Banner } from "~/components/common/Banner";
-import { AddressField } from "~/components/forms/AddressField";
-import { CheckboxField } from "~/components/forms/CheckboxField";
+import { Banner } from "#components/common/Banner";
+import { AddressField } from "#components/forms/AddressField";
+import { CheckboxField } from "#components/forms/CheckboxField";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { defineStep } from "~/forms/defineStep";
+} from "#components/forms/FormStep";
+import { defineStep } from "#forms/defineStep";
 
 const whenNotUnhoused = (data: Record<string, unknown>) =>
   data.isCurrentlyUnhoused !== true;

--- a/src/content/forms/court-order-ma/steps/BirthplaceStep.tsx
+++ b/src/content/forms/court-order-ma/steps/BirthplaceStep.tsx
@@ -1,12 +1,9 @@
-import { ComboBoxField } from "../../../../components/forms/ComboBoxField";
-import {
-  FormStep,
-  useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { COUNTRIES } from "../../../../constants/countries";
-import { JURISDICTIONS } from "../../../../constants/jurisdictions";
-import { defineStep } from "../../../../forms/defineStep";
+import { ComboBoxField } from "~/components/forms/ComboBoxField";
+import { FormStep, useFieldVisible } from "~/components/forms/FormStep";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { COUNTRIES } from "~/constants/countries";
+import { JURISDICTIONS } from "~/constants/jurisdictions";
+import { defineStep } from "~/forms/defineStep";
 
 export const birthplaceStep = defineStep({
   id: "birthplace",

--- a/src/content/forms/court-order-ma/steps/BirthplaceStep.tsx
+++ b/src/content/forms/court-order-ma/steps/BirthplaceStep.tsx
@@ -1,9 +1,9 @@
-import { ComboBoxField } from "~/components/forms/ComboBoxField";
-import { FormStep, useFieldVisible } from "~/components/forms/FormStep";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { COUNTRIES } from "~/constants/countries";
-import { JURISDICTIONS } from "~/constants/jurisdictions";
-import { defineStep } from "~/forms/defineStep";
+import { ComboBoxField } from "#components/forms/ComboBoxField";
+import { FormStep, useFieldVisible } from "#components/forms/FormStep";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { COUNTRIES } from "#constants/countries";
+import { JURISDICTIONS } from "#constants/jurisdictions";
+import { defineStep } from "#forms/defineStep";
 
 export const birthplaceStep = defineStep({
   id: "birthplace",

--- a/src/content/forms/court-order-ma/steps/ContactInfoStep.tsx
+++ b/src/content/forms/court-order-ma/steps/ContactInfoStep.tsx
@@ -1,7 +1,7 @@
-import { EmailField } from "~/components/forms/EmailField";
-import { FormStep } from "~/components/forms/FormStep";
-import { PhoneField } from "~/components/forms/PhoneField";
-import { defineStep } from "~/forms/defineStep";
+import { EmailField } from "#components/forms/EmailField";
+import { FormStep } from "#components/forms/FormStep";
+import { PhoneField } from "#components/forms/PhoneField";
+import { defineStep } from "#forms/defineStep";
 
 export const contactInfoStep = defineStep({
   id: "contact-info",

--- a/src/content/forms/court-order-ma/steps/ContactInfoStep.tsx
+++ b/src/content/forms/court-order-ma/steps/ContactInfoStep.tsx
@@ -1,7 +1,7 @@
-import { EmailField } from "../../../../components/forms/EmailField";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { PhoneField } from "../../../../components/forms/PhoneField";
-import { defineStep } from "../../../../forms/defineStep";
+import { EmailField } from "~/components/forms/EmailField";
+import { FormStep } from "~/components/forms/FormStep";
+import { PhoneField } from "~/components/forms/PhoneField";
+import { defineStep } from "~/forms/defineStep";
 
 export const contactInfoStep = defineStep({
   id: "contact-info",

--- a/src/content/forms/court-order-ma/steps/CurrentNameStep.tsx
+++ b/src/content/forms/court-order-ma/steps/CurrentNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { defineStep } from "~/forms/defineStep";
 
 export const currentNameStep = defineStep({
   id: "current-name",

--- a/src/content/forms/court-order-ma/steps/CurrentNameStep.tsx
+++ b/src/content/forms/court-order-ma/steps/CurrentNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { defineStep } from "#forms/defineStep";
 
 export const currentNameStep = defineStep({
   id: "current-name",

--- a/src/content/forms/court-order-ma/steps/DateOfBirthStep.tsx
+++ b/src/content/forms/court-order-ma/steps/DateOfBirthStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { MemorableDateField } from "../../../../components/forms/MemorableDateField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { MemorableDateField } from "~/components/forms/MemorableDateField";
+import { defineStep } from "~/forms/defineStep";
 
 export const dateOfBirthStep = defineStep({
   id: "date-of-birth",

--- a/src/content/forms/court-order-ma/steps/DateOfBirthStep.tsx
+++ b/src/content/forms/court-order-ma/steps/DateOfBirthStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { MemorableDateField } from "~/components/forms/MemorableDateField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { MemorableDateField } from "#components/forms/MemorableDateField";
+import { defineStep } from "#forms/defineStep";
 
 export const dateOfBirthStep = defineStep({
   id: "date-of-birth",

--- a/src/content/forms/court-order-ma/steps/ImpoundCaseStep.tsx
+++ b/src/content/forms/court-order-ma/steps/ImpoundCaseStep.tsx
@@ -1,12 +1,12 @@
-import { Banner } from "../../../../components/common/Banner";
+import { Banner } from "~/components/common/Banner";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { LongTextField } from "../../../../components/forms/LongTextField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+} from "~/components/forms/FormStep";
+import { LongTextField } from "~/components/forms/LongTextField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const impoundCaseStep = defineStep({
   id: "impound-case",

--- a/src/content/forms/court-order-ma/steps/ImpoundCaseStep.tsx
+++ b/src/content/forms/court-order-ma/steps/ImpoundCaseStep.tsx
@@ -1,12 +1,12 @@
-import { Banner } from "~/components/common/Banner";
+import { Banner } from "#components/common/Banner";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { LongTextField } from "~/components/forms/LongTextField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+} from "#components/forms/FormStep";
+import { LongTextField } from "#components/forms/LongTextField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const impoundCaseStep = defineStep({
   id: "impound-case",

--- a/src/content/forms/court-order-ma/steps/InterpreterStep.tsx
+++ b/src/content/forms/court-order-ma/steps/InterpreterStep.tsx
@@ -2,10 +2,10 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { LanguageSelectField } from "../../../../components/forms/LanguageSelectField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+} from "~/components/forms/FormStep";
+import { LanguageSelectField } from "~/components/forms/LanguageSelectField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const interpreterStep = defineStep({
   id: "interpreter",

--- a/src/content/forms/court-order-ma/steps/InterpreterStep.tsx
+++ b/src/content/forms/court-order-ma/steps/InterpreterStep.tsx
@@ -2,10 +2,10 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { LanguageSelectField } from "~/components/forms/LanguageSelectField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+} from "#components/forms/FormStep";
+import { LanguageSelectField } from "#components/forms/LanguageSelectField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const interpreterStep = defineStep({
   id: "interpreter",

--- a/src/content/forms/court-order-ma/steps/MothersMaidenNameStep.tsx
+++ b/src/content/forms/court-order-ma/steps/MothersMaidenNameStep.tsx
@@ -1,7 +1,7 @@
-import { Banner } from "~/components/common/Banner";
-import { FormStep } from "~/components/forms/FormStep";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { defineStep } from "~/forms/defineStep";
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { defineStep } from "#forms/defineStep";
 
 export const mothersMaidenNameStep = defineStep({
   id: "mothers-maiden-name",

--- a/src/content/forms/court-order-ma/steps/MothersMaidenNameStep.tsx
+++ b/src/content/forms/court-order-ma/steps/MothersMaidenNameStep.tsx
@@ -1,7 +1,7 @@
-import { Banner } from "../../../../components/common/Banner";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { defineStep } from "../../../../forms/defineStep";
+import { Banner } from "~/components/common/Banner";
+import { FormStep } from "~/components/forms/FormStep";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { defineStep } from "~/forms/defineStep";
 
 export const mothersMaidenNameStep = defineStep({
   id: "mothers-maiden-name",

--- a/src/content/forms/court-order-ma/steps/NewNameStep.tsx
+++ b/src/content/forms/court-order-ma/steps/NewNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { defineStep } from "~/forms/defineStep";
 
 export const newNameStep = defineStep({
   id: "new-name",

--- a/src/content/forms/court-order-ma/steps/NewNameStep.tsx
+++ b/src/content/forms/court-order-ma/steps/NewNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { defineStep } from "#forms/defineStep";
 
 export const newNameStep = defineStep({
   id: "new-name",

--- a/src/content/forms/court-order-ma/steps/OtherNamesStep.tsx
+++ b/src/content/forms/court-order-ma/steps/OtherNamesStep.tsx
@@ -1,12 +1,12 @@
-import { Banner } from "../../../../components/common/Banner";
+import { Banner } from "~/components/common/Banner";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { LongTextField } from "../../../../components/forms/LongTextField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+} from "~/components/forms/FormStep";
+import { LongTextField } from "~/components/forms/LongTextField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const otherNamesStep = defineStep({
   id: "other-names",

--- a/src/content/forms/court-order-ma/steps/OtherNamesStep.tsx
+++ b/src/content/forms/court-order-ma/steps/OtherNamesStep.tsx
@@ -1,12 +1,12 @@
-import { Banner } from "~/components/common/Banner";
+import { Banner } from "#components/common/Banner";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { LongTextField } from "~/components/forms/LongTextField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+} from "#components/forms/FormStep";
+import { LongTextField } from "#components/forms/LongTextField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const otherNamesStep = defineStep({
   id: "other-names",

--- a/src/content/forms/court-order-ma/steps/PreviousNameChangeStep.tsx
+++ b/src/content/forms/court-order-ma/steps/PreviousNameChangeStep.tsx
@@ -2,11 +2,11 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { LongTextField } from "~/components/forms/LongTextField";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+} from "#components/forms/FormStep";
+import { LongTextField } from "#components/forms/LongTextField";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const previousNameChangeStep = defineStep({
   id: "previous-name-change",

--- a/src/content/forms/court-order-ma/steps/PreviousNameChangeStep.tsx
+++ b/src/content/forms/court-order-ma/steps/PreviousNameChangeStep.tsx
@@ -2,11 +2,11 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { LongTextField } from "../../../../components/forms/LongTextField";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+} from "~/components/forms/FormStep";
+import { LongTextField } from "~/components/forms/LongTextField";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const previousNameChangeStep = defineStep({
   id: "previous-name-change",

--- a/src/content/forms/court-order-ma/steps/PronounsStep.tsx
+++ b/src/content/forms/court-order-ma/steps/PronounsStep.tsx
@@ -2,10 +2,10 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { PronounSelectField } from "~/components/forms/PronounSelectField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+} from "#components/forms/FormStep";
+import { PronounSelectField } from "#components/forms/PronounSelectField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const pronounsStep = defineStep({
   id: "pronouns",

--- a/src/content/forms/court-order-ma/steps/PronounsStep.tsx
+++ b/src/content/forms/court-order-ma/steps/PronounsStep.tsx
@@ -2,10 +2,10 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { PronounSelectField } from "../../../../components/forms/PronounSelectField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+} from "~/components/forms/FormStep";
+import { PronounSelectField } from "~/components/forms/PronounSelectField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const pronounsStep = defineStep({
   id: "pronouns",

--- a/src/content/forms/court-order-ma/steps/ReasonStep.tsx
+++ b/src/content/forms/court-order-ma/steps/ReasonStep.tsx
@@ -1,8 +1,8 @@
-import { Banner } from "../../../../components/common/Banner";
-import { CheckboxField } from "../../../../components/forms/CheckboxField";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { LongTextField } from "../../../../components/forms/LongTextField";
-import { defineStep } from "../../../../forms/defineStep";
+import { Banner } from "~/components/common/Banner";
+import { CheckboxField } from "~/components/forms/CheckboxField";
+import { FormStep } from "~/components/forms/FormStep";
+import { LongTextField } from "~/components/forms/LongTextField";
+import { defineStep } from "~/forms/defineStep";
 
 export const reasonStep = defineStep({
   id: "reason",

--- a/src/content/forms/court-order-ma/steps/ReasonStep.tsx
+++ b/src/content/forms/court-order-ma/steps/ReasonStep.tsx
@@ -1,8 +1,8 @@
-import { Banner } from "~/components/common/Banner";
-import { CheckboxField } from "~/components/forms/CheckboxField";
-import { FormStep } from "~/components/forms/FormStep";
-import { LongTextField } from "~/components/forms/LongTextField";
-import { defineStep } from "~/forms/defineStep";
+import { Banner } from "#components/common/Banner";
+import { CheckboxField } from "#components/forms/CheckboxField";
+import { FormStep } from "#components/forms/FormStep";
+import { LongTextField } from "#components/forms/LongTextField";
+import { defineStep } from "#forms/defineStep";
 
 export const reasonStep = defineStep({
   id: "reason",

--- a/src/content/forms/court-order-ri/index.ts
+++ b/src/content/forms/court-order-ri/index.ts
@@ -1,4 +1,4 @@
-import { defineForm } from "../../../forms/defineForm";
+import { defineForm } from "~/forms/defineForm";
 import { addressStep } from "./steps/AddressStep";
 import { birthCertificateStep } from "./steps/BirthCertificateStep";
 import { birthplaceStep } from "./steps/BirthplaceStep";

--- a/src/content/forms/court-order-ri/index.ts
+++ b/src/content/forms/court-order-ri/index.ts
@@ -1,4 +1,4 @@
-import { defineForm } from "~/forms/defineForm";
+import { defineForm } from "#forms/defineForm";
 import { addressStep } from "./steps/AddressStep";
 import { birthCertificateStep } from "./steps/BirthCertificateStep";
 import { birthplaceStep } from "./steps/BirthplaceStep";

--- a/src/content/forms/court-order-ri/steps/AddressStep.tsx
+++ b/src/content/forms/court-order-ri/steps/AddressStep.tsx
@@ -1,12 +1,12 @@
-import { Banner } from "../../../../components/common/Banner";
-import { AddressField } from "../../../../components/forms/AddressField";
-import { CheckboxField } from "../../../../components/forms/CheckboxField";
+import { Banner } from "~/components/common/Banner";
+import { AddressField } from "~/components/forms/AddressField";
+import { CheckboxField } from "~/components/forms/CheckboxField";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { defineStep } from "../../../../forms/defineStep";
+} from "~/components/forms/FormStep";
+import { defineStep } from "~/forms/defineStep";
 
 export const addressStep = defineStep({
   id: "address",

--- a/src/content/forms/court-order-ri/steps/AddressStep.tsx
+++ b/src/content/forms/court-order-ri/steps/AddressStep.tsx
@@ -1,12 +1,12 @@
-import { Banner } from "~/components/common/Banner";
-import { AddressField } from "~/components/forms/AddressField";
-import { CheckboxField } from "~/components/forms/CheckboxField";
+import { Banner } from "#components/common/Banner";
+import { AddressField } from "#components/forms/AddressField";
+import { CheckboxField } from "#components/forms/CheckboxField";
 import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { defineStep } from "~/forms/defineStep";
+} from "#components/forms/FormStep";
+import { defineStep } from "#forms/defineStep";
 
 export const addressStep = defineStep({
   id: "address",

--- a/src/content/forms/court-order-ri/steps/BirthCertificateStep.tsx
+++ b/src/content/forms/court-order-ri/steps/BirthCertificateStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const birthCertificateStep = defineStep({
   id: "birth-certificate",

--- a/src/content/forms/court-order-ri/steps/BirthCertificateStep.tsx
+++ b/src/content/forms/court-order-ri/steps/BirthCertificateStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const birthCertificateStep = defineStep({
   id: "birth-certificate",

--- a/src/content/forms/court-order-ri/steps/BirthplaceStep.tsx
+++ b/src/content/forms/court-order-ri/steps/BirthplaceStep.tsx
@@ -1,12 +1,9 @@
-import { ComboBoxField } from "../../../../components/forms/ComboBoxField";
-import {
-  FormStep,
-  useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { COUNTRIES } from "../../../../constants/countries";
-import { JURISDICTIONS } from "../../../../constants/jurisdictions";
-import { defineStep } from "../../../../forms/defineStep";
+import { ComboBoxField } from "~/components/forms/ComboBoxField";
+import { FormStep, useFieldVisible } from "~/components/forms/FormStep";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { COUNTRIES } from "~/constants/countries";
+import { JURISDICTIONS } from "~/constants/jurisdictions";
+import { defineStep } from "~/forms/defineStep";
 
 export const birthplaceStep = defineStep({
   id: "birthplace",

--- a/src/content/forms/court-order-ri/steps/BirthplaceStep.tsx
+++ b/src/content/forms/court-order-ri/steps/BirthplaceStep.tsx
@@ -1,9 +1,9 @@
-import { ComboBoxField } from "~/components/forms/ComboBoxField";
-import { FormStep, useFieldVisible } from "~/components/forms/FormStep";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { COUNTRIES } from "~/constants/countries";
-import { JURISDICTIONS } from "~/constants/jurisdictions";
-import { defineStep } from "~/forms/defineStep";
+import { ComboBoxField } from "#components/forms/ComboBoxField";
+import { FormStep, useFieldVisible } from "#components/forms/FormStep";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { COUNTRIES } from "#constants/countries";
+import { JURISDICTIONS } from "#constants/jurisdictions";
+import { defineStep } from "#forms/defineStep";
 
 export const birthplaceStep = defineStep({
   id: "birthplace",

--- a/src/content/forms/court-order-ri/steps/ContactInfoStep.tsx
+++ b/src/content/forms/court-order-ri/steps/ContactInfoStep.tsx
@@ -1,7 +1,7 @@
-import { EmailField } from "~/components/forms/EmailField";
-import { FormStep } from "~/components/forms/FormStep";
-import { PhoneField } from "~/components/forms/PhoneField";
-import { defineStep } from "~/forms/defineStep";
+import { EmailField } from "#components/forms/EmailField";
+import { FormStep } from "#components/forms/FormStep";
+import { PhoneField } from "#components/forms/PhoneField";
+import { defineStep } from "#forms/defineStep";
 
 export const contactInfoStep = defineStep({
   id: "contact-info",

--- a/src/content/forms/court-order-ri/steps/ContactInfoStep.tsx
+++ b/src/content/forms/court-order-ri/steps/ContactInfoStep.tsx
@@ -1,7 +1,7 @@
-import { EmailField } from "../../../../components/forms/EmailField";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { PhoneField } from "../../../../components/forms/PhoneField";
-import { defineStep } from "../../../../forms/defineStep";
+import { EmailField } from "~/components/forms/EmailField";
+import { FormStep } from "~/components/forms/FormStep";
+import { PhoneField } from "~/components/forms/PhoneField";
+import { defineStep } from "~/forms/defineStep";
 
 export const contactInfoStep = defineStep({
   id: "contact-info",

--- a/src/content/forms/court-order-ri/steps/CurrentNameStep.tsx
+++ b/src/content/forms/court-order-ri/steps/CurrentNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { defineStep } from "~/forms/defineStep";
 
 export const currentNameStep = defineStep({
   id: "current-name",

--- a/src/content/forms/court-order-ri/steps/CurrentNameStep.tsx
+++ b/src/content/forms/court-order-ri/steps/CurrentNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { defineStep } from "#forms/defineStep";
 
 export const currentNameStep = defineStep({
   id: "current-name",

--- a/src/content/forms/court-order-ri/steps/DateOfBirthStep.tsx
+++ b/src/content/forms/court-order-ri/steps/DateOfBirthStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { MemorableDateField } from "../../../../components/forms/MemorableDateField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { MemorableDateField } from "~/components/forms/MemorableDateField";
+import { defineStep } from "~/forms/defineStep";
 
 export const dateOfBirthStep = defineStep({
   id: "date-of-birth",

--- a/src/content/forms/court-order-ri/steps/DateOfBirthStep.tsx
+++ b/src/content/forms/court-order-ri/steps/DateOfBirthStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { MemorableDateField } from "~/components/forms/MemorableDateField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { MemorableDateField } from "#components/forms/MemorableDateField";
+import { defineStep } from "#forms/defineStep";
 
 export const dateOfBirthStep = defineStep({
   id: "date-of-birth",

--- a/src/content/forms/court-order-ri/steps/FamilyInfoStep.tsx
+++ b/src/content/forms/court-order-ri/steps/FamilyInfoStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep, FormSubsection } from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep, FormSubsection } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { defineStep } from "#forms/defineStep";
 
 export const familyInfoStep = defineStep({
   id: "family-info",

--- a/src/content/forms/court-order-ri/steps/FamilyInfoStep.tsx
+++ b/src/content/forms/court-order-ri/steps/FamilyInfoStep.tsx
@@ -1,9 +1,6 @@
-import {
-  FormStep,
-  FormSubsection,
-} from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep, FormSubsection } from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { defineStep } from "~/forms/defineStep";
 
 export const familyInfoStep = defineStep({
   id: "family-info",

--- a/src/content/forms/court-order-ri/steps/NewNameStep.tsx
+++ b/src/content/forms/court-order-ri/steps/NewNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { defineStep } from "~/forms/defineStep";
 
 export const newNameStep = defineStep({
   id: "new-name",

--- a/src/content/forms/court-order-ri/steps/NewNameStep.tsx
+++ b/src/content/forms/court-order-ri/steps/NewNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { defineStep } from "#forms/defineStep";
 
 export const newNameStep = defineStep({
   id: "new-name",

--- a/src/content/forms/court-order-ri/steps/PersonalInfoStep.tsx
+++ b/src/content/forms/court-order-ri/steps/PersonalInfoStep.tsx
@@ -1,7 +1,7 @@
-import { ComboBoxField } from "../../../../components/forms/ComboBoxField";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { defineStep } from "../../../../forms/defineStep";
+import { ComboBoxField } from "~/components/forms/ComboBoxField";
+import { FormStep } from "~/components/forms/FormStep";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { defineStep } from "~/forms/defineStep";
 
 const MARITAL_STATUS_OPTIONS = [
   { label: "Single", value: "Single" },

--- a/src/content/forms/court-order-ri/steps/PersonalInfoStep.tsx
+++ b/src/content/forms/court-order-ri/steps/PersonalInfoStep.tsx
@@ -1,7 +1,7 @@
-import { ComboBoxField } from "~/components/forms/ComboBoxField";
-import { FormStep } from "~/components/forms/FormStep";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { defineStep } from "~/forms/defineStep";
+import { ComboBoxField } from "#components/forms/ComboBoxField";
+import { FormStep } from "#components/forms/FormStep";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { defineStep } from "#forms/defineStep";
 
 const MARITAL_STATUS_OPTIONS = [
   { label: "Single", value: "Single" },

--- a/src/content/forms/court-order-ri/steps/PreviousAddressesStep.tsx
+++ b/src/content/forms/court-order-ri/steps/PreviousAddressesStep.tsx
@@ -1,7 +1,7 @@
-import { TextField } from "~/components/common/TextField";
-import { FormStep } from "~/components/forms/FormStep";
-import { RepeatingEntry } from "~/components/forms/RepeatingEntry";
-import { defineStep } from "~/forms/defineStep";
+import { TextField } from "#components/common/TextField";
+import { FormStep } from "#components/forms/FormStep";
+import { RepeatingEntry } from "#components/forms/RepeatingEntry";
+import { defineStep } from "#forms/defineStep";
 
 export const previousAddressesStep = defineStep({
   id: "previous-addresses",

--- a/src/content/forms/court-order-ri/steps/PreviousAddressesStep.tsx
+++ b/src/content/forms/court-order-ri/steps/PreviousAddressesStep.tsx
@@ -1,7 +1,7 @@
-import { TextField } from "../../../../components/common/TextField";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { RepeatingEntry } from "../../../../components/forms/RepeatingEntry";
-import { defineStep } from "../../../../forms/defineStep";
+import { TextField } from "~/components/common/TextField";
+import { FormStep } from "~/components/forms/FormStep";
+import { RepeatingEntry } from "~/components/forms/RepeatingEntry";
+import { defineStep } from "~/forms/defineStep";
 
 export const previousAddressesStep = defineStep({
   id: "previous-addresses",

--- a/src/content/forms/court-order-ri/steps/PreviousNameChangeStep.tsx
+++ b/src/content/forms/court-order-ri/steps/PreviousNameChangeStep.tsx
@@ -1,8 +1,8 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "~/components/common/Banner";
-import { FormStep } from "~/components/forms/FormStep";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const previousNameChangeStep = defineStep({
   id: "previous-name-change",

--- a/src/content/forms/court-order-ri/steps/PreviousNameChangeStep.tsx
+++ b/src/content/forms/court-order-ri/steps/PreviousNameChangeStep.tsx
@@ -1,8 +1,8 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "../../../../components/common/Banner";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+import { Banner } from "~/components/common/Banner";
+import { FormStep } from "~/components/forms/FormStep";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const previousNameChangeStep = defineStep({
   id: "previous-name-change",

--- a/src/content/forms/court-order-ri/steps/ReasonStep.tsx
+++ b/src/content/forms/court-order-ri/steps/ReasonStep.tsx
@@ -1,7 +1,7 @@
-import { Banner } from "../../../../components/common/Banner";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { LongTextField } from "../../../../components/forms/LongTextField";
-import { defineStep } from "../../../../forms/defineStep";
+import { Banner } from "~/components/common/Banner";
+import { FormStep } from "~/components/forms/FormStep";
+import { LongTextField } from "~/components/forms/LongTextField";
+import { defineStep } from "~/forms/defineStep";
 
 export const reasonStep = defineStep({
   id: "reason",

--- a/src/content/forms/court-order-ri/steps/ReasonStep.tsx
+++ b/src/content/forms/court-order-ri/steps/ReasonStep.tsx
@@ -1,7 +1,7 @@
-import { Banner } from "~/components/common/Banner";
-import { FormStep } from "~/components/forms/FormStep";
-import { LongTextField } from "~/components/forms/LongTextField";
-import { defineStep } from "~/forms/defineStep";
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { LongTextField } from "#components/forms/LongTextField";
+import { defineStep } from "#forms/defineStep";
 
 export const reasonStep = defineStep({
   id: "reason",

--- a/src/content/forms/social-security/index.ts
+++ b/src/content/forms/social-security/index.ts
@@ -1,4 +1,4 @@
-import { defineForm } from "~/forms/defineForm";
+import { defineForm } from "#forms/defineForm";
 import { addressStep } from "./steps/AddressStep";
 import { birthplaceStep } from "./steps/BirthplaceStep";
 import { citizenshipStep } from "./steps/CitizenshipStep";

--- a/src/content/forms/social-security/index.ts
+++ b/src/content/forms/social-security/index.ts
@@ -1,4 +1,4 @@
-import { defineForm } from "../../../forms/defineForm";
+import { defineForm } from "~/forms/defineForm";
 import { addressStep } from "./steps/AddressStep";
 import { birthplaceStep } from "./steps/BirthplaceStep";
 import { citizenshipStep } from "./steps/CitizenshipStep";

--- a/src/content/forms/social-security/steps/AddressStep.tsx
+++ b/src/content/forms/social-security/steps/AddressStep.tsx
@@ -1,6 +1,6 @@
-import { AddressField } from "~/components/forms/AddressField";
-import { FormStep } from "~/components/forms/FormStep";
-import { defineStep } from "~/forms/defineStep";
+import { AddressField } from "#components/forms/AddressField";
+import { FormStep } from "#components/forms/FormStep";
+import { defineStep } from "#forms/defineStep";
 
 export const addressStep = defineStep({
   id: "address",

--- a/src/content/forms/social-security/steps/AddressStep.tsx
+++ b/src/content/forms/social-security/steps/AddressStep.tsx
@@ -1,6 +1,6 @@
-import { AddressField } from "../../../../components/forms/AddressField";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { defineStep } from "../../../../forms/defineStep";
+import { AddressField } from "~/components/forms/AddressField";
+import { FormStep } from "~/components/forms/FormStep";
+import { defineStep } from "~/forms/defineStep";
 
 export const addressStep = defineStep({
   id: "address",

--- a/src/content/forms/social-security/steps/BirthplaceStep.tsx
+++ b/src/content/forms/social-security/steps/BirthplaceStep.tsx
@@ -1,12 +1,9 @@
-import { ComboBoxField } from "../../../../components/forms/ComboBoxField";
-import {
-  FormStep,
-  useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { COUNTRIES } from "../../../../constants/countries";
-import { JURISDICTIONS } from "../../../../constants/jurisdictions";
-import { defineStep } from "../../../../forms/defineStep";
+import { ComboBoxField } from "~/components/forms/ComboBoxField";
+import { FormStep, useFieldVisible } from "~/components/forms/FormStep";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { COUNTRIES } from "~/constants/countries";
+import { JURISDICTIONS } from "~/constants/jurisdictions";
+import { defineStep } from "~/forms/defineStep";
 
 export const birthplaceStep = defineStep({
   id: "birthplace",

--- a/src/content/forms/social-security/steps/BirthplaceStep.tsx
+++ b/src/content/forms/social-security/steps/BirthplaceStep.tsx
@@ -1,9 +1,9 @@
-import { ComboBoxField } from "~/components/forms/ComboBoxField";
-import { FormStep, useFieldVisible } from "~/components/forms/FormStep";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { COUNTRIES } from "~/constants/countries";
-import { JURISDICTIONS } from "~/constants/jurisdictions";
-import { defineStep } from "~/forms/defineStep";
+import { ComboBoxField } from "#components/forms/ComboBoxField";
+import { FormStep, useFieldVisible } from "#components/forms/FormStep";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { COUNTRIES } from "#constants/countries";
+import { JURISDICTIONS } from "#constants/jurisdictions";
+import { defineStep } from "#forms/defineStep";
 
 export const birthplaceStep = defineStep({
   id: "birthplace",

--- a/src/content/forms/social-security/steps/CitizenshipStep.tsx
+++ b/src/content/forms/social-security/steps/CitizenshipStep.tsx
@@ -1,8 +1,8 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "~/components/common/Banner";
-import { FormStep } from "~/components/forms/FormStep";
-import { RadioGroupField } from "~/components/forms/RadioGroupField";
-import { defineStep } from "~/forms/defineStep";
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { RadioGroupField } from "#components/forms/RadioGroupField";
+import { defineStep } from "#forms/defineStep";
 
 export const citizenshipStep = defineStep({
   id: "citizenship",

--- a/src/content/forms/social-security/steps/CitizenshipStep.tsx
+++ b/src/content/forms/social-security/steps/CitizenshipStep.tsx
@@ -1,8 +1,8 @@
 import { useFormContext } from "react-hook-form";
-import { Banner } from "../../../../components/common/Banner";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { RadioGroupField } from "../../../../components/forms/RadioGroupField";
-import { defineStep } from "../../../../forms/defineStep";
+import { Banner } from "~/components/common/Banner";
+import { FormStep } from "~/components/forms/FormStep";
+import { RadioGroupField } from "~/components/forms/RadioGroupField";
+import { defineStep } from "~/forms/defineStep";
 
 export const citizenshipStep = defineStep({
   id: "citizenship",

--- a/src/content/forms/social-security/steps/DateOfBirthStep.tsx
+++ b/src/content/forms/social-security/steps/DateOfBirthStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { MemorableDateField } from "../../../../components/forms/MemorableDateField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { MemorableDateField } from "~/components/forms/MemorableDateField";
+import { defineStep } from "~/forms/defineStep";
 
 export const dateOfBirthStep = defineStep({
   id: "date-of-birth",

--- a/src/content/forms/social-security/steps/DateOfBirthStep.tsx
+++ b/src/content/forms/social-security/steps/DateOfBirthStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { MemorableDateField } from "~/components/forms/MemorableDateField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { MemorableDateField } from "#components/forms/MemorableDateField";
+import { defineStep } from "#forms/defineStep";
 
 export const dateOfBirthStep = defineStep({
   id: "date-of-birth",

--- a/src/content/forms/social-security/steps/EthnicityStep.tsx
+++ b/src/content/forms/social-security/steps/EthnicityStep.tsx
@@ -1,7 +1,7 @@
-import { Banner } from "../../../../components/common/Banner";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+import { Banner } from "~/components/common/Banner";
+import { FormStep } from "~/components/forms/FormStep";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const ethnicityStep = defineStep({
   id: "ethnicity",

--- a/src/content/forms/social-security/steps/EthnicityStep.tsx
+++ b/src/content/forms/social-security/steps/EthnicityStep.tsx
@@ -1,7 +1,7 @@
-import { Banner } from "~/components/common/Banner";
-import { FormStep } from "~/components/forms/FormStep";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const ethnicityStep = defineStep({
   id: "ethnicity",

--- a/src/content/forms/social-security/steps/FilingForSomeoneElseStep.tsx
+++ b/src/content/forms/social-security/steps/FilingForSomeoneElseStep.tsx
@@ -2,11 +2,11 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { RadioGroupField } from "~/components/forms/RadioGroupField";
-import { ShortTextField } from "~/components/forms/ShortTextField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+} from "#components/forms/FormStep";
+import { RadioGroupField } from "#components/forms/RadioGroupField";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const filingForSomeoneElseStep = defineStep({
   id: "filing-for-someone-else",

--- a/src/content/forms/social-security/steps/FilingForSomeoneElseStep.tsx
+++ b/src/content/forms/social-security/steps/FilingForSomeoneElseStep.tsx
@@ -2,11 +2,11 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { RadioGroupField } from "../../../../components/forms/RadioGroupField";
-import { ShortTextField } from "../../../../components/forms/ShortTextField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+} from "~/components/forms/FormStep";
+import { RadioGroupField } from "~/components/forms/RadioGroupField";
+import { ShortTextField } from "~/components/forms/ShortTextField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const filingForSomeoneElseStep = defineStep({
   id: "filing-for-someone-else",

--- a/src/content/forms/social-security/steps/NewNameStep.tsx
+++ b/src/content/forms/social-security/steps/NewNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { defineStep } from "~/forms/defineStep";
 
 export const newNameStep = defineStep({
   id: "new-name",

--- a/src/content/forms/social-security/steps/NewNameStep.tsx
+++ b/src/content/forms/social-security/steps/NewNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { defineStep } from "#forms/defineStep";
 
 export const newNameStep = defineStep({
   id: "new-name",

--- a/src/content/forms/social-security/steps/OldNameStep.tsx
+++ b/src/content/forms/social-security/steps/OldNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { defineStep } from "~/forms/defineStep";
 
 export const oldNameStep = defineStep({
   id: "old-name",

--- a/src/content/forms/social-security/steps/OldNameStep.tsx
+++ b/src/content/forms/social-security/steps/OldNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { defineStep } from "#forms/defineStep";
 
 export const oldNameStep = defineStep({
   id: "old-name",

--- a/src/content/forms/social-security/steps/ParentOneNameStep.tsx
+++ b/src/content/forms/social-security/steps/ParentOneNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { defineStep } from "#forms/defineStep";
 
 export const parentOneNameStep = defineStep({
   id: "parent-one",

--- a/src/content/forms/social-security/steps/ParentOneNameStep.tsx
+++ b/src/content/forms/social-security/steps/ParentOneNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { defineStep } from "~/forms/defineStep";
 
 export const parentOneNameStep = defineStep({
   id: "parent-one",

--- a/src/content/forms/social-security/steps/ParentTwoNameStep.tsx
+++ b/src/content/forms/social-security/steps/ParentTwoNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { defineStep } from "#forms/defineStep";
 
 export const parentTwoNameStep = defineStep({
   id: "parent-two",

--- a/src/content/forms/social-security/steps/ParentTwoNameStep.tsx
+++ b/src/content/forms/social-security/steps/ParentTwoNameStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { defineStep } from "~/forms/defineStep";
 
 export const parentTwoNameStep = defineStep({
   id: "parent-two",

--- a/src/content/forms/social-security/steps/PhoneNumberStep.tsx
+++ b/src/content/forms/social-security/steps/PhoneNumberStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "../../../../components/forms/FormStep";
-import { PhoneField } from "../../../../components/forms/PhoneField";
-import { defineStep } from "../../../../forms/defineStep";
+import { FormStep } from "~/components/forms/FormStep";
+import { PhoneField } from "~/components/forms/PhoneField";
+import { defineStep } from "~/forms/defineStep";
 
 export const phoneNumberStep = defineStep({
   id: "phone-number",

--- a/src/content/forms/social-security/steps/PhoneNumberStep.tsx
+++ b/src/content/forms/social-security/steps/PhoneNumberStep.tsx
@@ -1,6 +1,6 @@
-import { FormStep } from "~/components/forms/FormStep";
-import { PhoneField } from "~/components/forms/PhoneField";
-import { defineStep } from "~/forms/defineStep";
+import { FormStep } from "#components/forms/FormStep";
+import { PhoneField } from "#components/forms/PhoneField";
+import { defineStep } from "#forms/defineStep";
 
 export const phoneNumberStep = defineStep({
   id: "phone-number",

--- a/src/content/forms/social-security/steps/PreviousNamesStep.tsx
+++ b/src/content/forms/social-security/steps/PreviousNamesStep.tsx
@@ -2,10 +2,10 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { LongTextField } from "~/components/forms/LongTextField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+} from "#components/forms/FormStep";
+import { LongTextField } from "#components/forms/LongTextField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const previousNamesStep = defineStep({
   id: "previous-names",

--- a/src/content/forms/social-security/steps/PreviousNamesStep.tsx
+++ b/src/content/forms/social-security/steps/PreviousNamesStep.tsx
@@ -2,10 +2,10 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { LongTextField } from "../../../../components/forms/LongTextField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+} from "~/components/forms/FormStep";
+import { LongTextField } from "~/components/forms/LongTextField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const previousNamesStep = defineStep({
   id: "previous-names",

--- a/src/content/forms/social-security/steps/PreviousSocialSecurityCardStep.tsx
+++ b/src/content/forms/social-security/steps/PreviousSocialSecurityCardStep.tsx
@@ -2,10 +2,10 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "~/components/forms/FormStep";
-import { NameField } from "~/components/forms/NameField";
-import { YesNoField } from "~/components/forms/YesNoField";
-import { defineStep } from "~/forms/defineStep";
+} from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#forms/defineStep";
 
 export const previousSocialSecurityCardStep = defineStep({
   id: "previous-social-security-card",

--- a/src/content/forms/social-security/steps/PreviousSocialSecurityCardStep.tsx
+++ b/src/content/forms/social-security/steps/PreviousSocialSecurityCardStep.tsx
@@ -2,10 +2,10 @@ import {
   FormStep,
   FormSubsection,
   useFieldVisible,
-} from "../../../../components/forms/FormStep";
-import { NameField } from "../../../../components/forms/NameField";
-import { YesNoField } from "../../../../components/forms/YesNoField";
-import { defineStep } from "../../../../forms/defineStep";
+} from "~/components/forms/FormStep";
+import { NameField } from "~/components/forms/NameField";
+import { YesNoField } from "~/components/forms/YesNoField";
+import { defineStep } from "~/forms/defineStep";
 
 export const previousSocialSecurityCardStep = defineStep({
   id: "previous-social-security-card",

--- a/src/content/forms/social-security/steps/RaceStep.tsx
+++ b/src/content/forms/social-security/steps/RaceStep.tsx
@@ -1,7 +1,7 @@
-import { Banner } from "~/components/common/Banner";
-import { CheckboxGroupField } from "~/components/forms/CheckboxGroupField";
-import { FormStep } from "~/components/forms/FormStep";
-import { defineStep } from "~/forms/defineStep";
+import { Banner } from "#components/common/Banner";
+import { CheckboxGroupField } from "#components/forms/CheckboxGroupField";
+import { FormStep } from "#components/forms/FormStep";
+import { defineStep } from "#forms/defineStep";
 
 export const raceStep = defineStep({
   id: "race",

--- a/src/content/forms/social-security/steps/RaceStep.tsx
+++ b/src/content/forms/social-security/steps/RaceStep.tsx
@@ -1,7 +1,7 @@
-import { Banner } from "../../../../components/common/Banner";
-import { CheckboxGroupField } from "../../../../components/forms/CheckboxGroupField";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { defineStep } from "../../../../forms/defineStep";
+import { Banner } from "~/components/common/Banner";
+import { CheckboxGroupField } from "~/components/forms/CheckboxGroupField";
+import { FormStep } from "~/components/forms/FormStep";
+import { defineStep } from "~/forms/defineStep";
 
 export const raceStep = defineStep({
   id: "race",

--- a/src/content/forms/social-security/steps/SexStep.tsx
+++ b/src/content/forms/social-security/steps/SexStep.tsx
@@ -1,7 +1,7 @@
-import { Banner } from "../../../../components/common/Banner";
-import { FormStep } from "../../../../components/forms/FormStep";
-import { RadioGroupField } from "../../../../components/forms/RadioGroupField";
-import { defineStep } from "../../../../forms/defineStep";
+import { Banner } from "~/components/common/Banner";
+import { FormStep } from "~/components/forms/FormStep";
+import { RadioGroupField } from "~/components/forms/RadioGroupField";
+import { defineStep } from "~/forms/defineStep";
 
 export const sexStep = defineStep({
   id: "sex",

--- a/src/content/forms/social-security/steps/SexStep.tsx
+++ b/src/content/forms/social-security/steps/SexStep.tsx
@@ -1,7 +1,7 @@
-import { Banner } from "~/components/common/Banner";
-import { FormStep } from "~/components/forms/FormStep";
-import { RadioGroupField } from "~/components/forms/RadioGroupField";
-import { defineStep } from "~/forms/defineStep";
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { RadioGroupField } from "#components/forms/RadioGroupField";
+import { defineStep } from "#forms/defineStep";
 
 export const sexStep = defineStep({
   id: "sex",

--- a/src/content/guides/ma/court-order.mdx
+++ b/src/content/guides/ma/court-order.mdx
@@ -5,8 +5,8 @@ state: ma
 category: court-order
 ---
 
-import Costs from "#components/Costs.astro"
-import { FormContainer } from "#components/forms/FormContainer/FormContainer"
+import Costs from "../../../components/Costs.astro"
+import { FormContainer } from "../../../components/forms/FormContainer/FormContainer"
 
 ## Get prepared
 

--- a/src/content/guides/ma/court-order.mdx
+++ b/src/content/guides/ma/court-order.mdx
@@ -5,8 +5,8 @@ state: ma
 category: court-order
 ---
 
-import Costs from "../../../components/Costs.astro"
-import { FormContainer } from "../../../components/forms/FormContainer/FormContainer"
+import Costs from "~/components/Costs.astro"
+import { FormContainer } from "~/components/forms/FormContainer/FormContainer"
 
 ## Get prepared
 

--- a/src/content/guides/ma/court-order.mdx
+++ b/src/content/guides/ma/court-order.mdx
@@ -6,7 +6,7 @@ category: court-order
 ---
 
 import Costs from "../../../components/Costs.astro"
-import { FormContainer } from "../../../components/forms/FormContainer/FormContainer"
+import { FormContainer } from "../../../components/forms/FormContainer"
 
 ## Get prepared
 

--- a/src/content/guides/ma/court-order.mdx
+++ b/src/content/guides/ma/court-order.mdx
@@ -5,8 +5,8 @@ state: ma
 category: court-order
 ---
 
-import Costs from "~/components/Costs.astro"
-import { FormContainer } from "~/components/forms/FormContainer/FormContainer"
+import Costs from "#components/Costs.astro"
+import { FormContainer } from "#components/forms/FormContainer/FormContainer"
 
 ## Get prepared
 

--- a/src/content/guides/ma/state-id.mdx
+++ b/src/content/guides/ma/state-id.mdx
@@ -5,7 +5,7 @@ state: ma
 category: state-id
 ---
 
-import Costs from "#components/Costs.astro"
+import Costs from "../../../components/Costs.astro"
 
 ## Get prepared
 

--- a/src/content/guides/ma/state-id.mdx
+++ b/src/content/guides/ma/state-id.mdx
@@ -5,7 +5,7 @@ state: ma
 category: state-id
 ---
 
-import Costs from "~/components/Costs.astro"
+import Costs from "#components/Costs.astro"
 
 ## Get prepared
 

--- a/src/content/guides/ma/state-id.mdx
+++ b/src/content/guides/ma/state-id.mdx
@@ -5,7 +5,7 @@ state: ma
 category: state-id
 ---
 
-import Costs from "../../../components/Costs.astro"
+import Costs from "~/components/Costs.astro"
 
 ## Get prepared
 

--- a/src/content/guides/passport.mdx
+++ b/src/content/guides/passport.mdx
@@ -4,7 +4,7 @@ description: Before updating your Passport, you will need a completed court orde
 category: passport
 ---
 
-import Costs from "../../components/Costs.astro"
+import Costs from "~/components/Costs.astro"
 
 **Update November 6, 2025:**
 

--- a/src/content/guides/passport.mdx
+++ b/src/content/guides/passport.mdx
@@ -4,7 +4,7 @@ description: Before updating your Passport, you will need a completed court orde
 category: passport
 ---
 
-import Costs from "#components/Costs.astro"
+import Costs from "../../components/Costs.astro"
 
 **Update November 6, 2025:**
 

--- a/src/content/guides/passport.mdx
+++ b/src/content/guides/passport.mdx
@@ -4,7 +4,7 @@ description: Before updating your Passport, you will need a completed court orde
 category: passport
 ---
 
-import Costs from "~/components/Costs.astro"
+import Costs from "#components/Costs.astro"
 
 **Update November 6, 2025:**
 

--- a/src/content/guides/ri/birth-certificate.mdx
+++ b/src/content/guides/ri/birth-certificate.mdx
@@ -5,7 +5,7 @@ state: ri
 category: birth-certificate
 ---
 
-import Costs from "~/components/Costs.astro"
+import Costs from "#components/Costs.astro"
 
 In Rhode Island, changes to birth certificates are handled by the Rhode Island Department of Health's [Office of Vital Records](https://health.ri.gov/vital-records).
 

--- a/src/content/guides/ri/birth-certificate.mdx
+++ b/src/content/guides/ri/birth-certificate.mdx
@@ -5,7 +5,7 @@ state: ri
 category: birth-certificate
 ---
 
-import Costs from "../../../components/Costs.astro"
+import Costs from "~/components/Costs.astro"
 
 In Rhode Island, changes to birth certificates are handled by the Rhode Island Department of Health's [Office of Vital Records](https://health.ri.gov/vital-records).
 

--- a/src/content/guides/ri/birth-certificate.mdx
+++ b/src/content/guides/ri/birth-certificate.mdx
@@ -5,7 +5,7 @@ state: ri
 category: birth-certificate
 ---
 
-import Costs from "#components/Costs.astro"
+import Costs from "../../../components/Costs.astro"
 
 In Rhode Island, changes to birth certificates are handled by the Rhode Island Department of Health's [Office of Vital Records](https://health.ri.gov/vital-records).
 

--- a/src/content/guides/ri/court-order.mdx
+++ b/src/content/guides/ri/court-order.mdx
@@ -5,7 +5,7 @@ state: ri
 category: court-order
 ---
 
-import { FormContainer } from "../../../components/forms/FormContainer/FormContainer"
+import { FormContainer } from "~/components/forms/FormContainer/FormContainer"
 
 ## Get prepared
 

--- a/src/content/guides/ri/court-order.mdx
+++ b/src/content/guides/ri/court-order.mdx
@@ -5,7 +5,7 @@ state: ri
 category: court-order
 ---
 
-import { FormContainer } from "../../../components/forms/FormContainer/FormContainer"
+import { FormContainer } from "../../../components/forms/FormContainer"
 
 ## Get prepared
 

--- a/src/content/guides/ri/court-order.mdx
+++ b/src/content/guides/ri/court-order.mdx
@@ -5,7 +5,7 @@ state: ri
 category: court-order
 ---
 
-import { FormContainer } from "~/components/forms/FormContainer/FormContainer"
+import { FormContainer } from "#components/forms/FormContainer/FormContainer"
 
 ## Get prepared
 

--- a/src/content/guides/ri/court-order.mdx
+++ b/src/content/guides/ri/court-order.mdx
@@ -5,7 +5,7 @@ state: ri
 category: court-order
 ---
 
-import { FormContainer } from "#components/forms/FormContainer/FormContainer"
+import { FormContainer } from "../../../components/forms/FormContainer/FormContainer"
 
 ## Get prepared
 

--- a/src/content/guides/social-security.mdx
+++ b/src/content/guides/social-security.mdx
@@ -4,7 +4,7 @@ description: Changing your name with Social Security is required to update some 
 category: social-security
 ---
 
-import { FormContainer } from "../../components/forms/FormContainer/FormContainer"
+import { FormContainer } from "~/components/forms/FormContainer/FormContainer"
 
 ## Get prepared
 

--- a/src/content/guides/social-security.mdx
+++ b/src/content/guides/social-security.mdx
@@ -4,7 +4,7 @@ description: Changing your name with Social Security is required to update some 
 category: social-security
 ---
 
-import { FormContainer } from "../../components/forms/FormContainer/FormContainer"
+import { FormContainer } from "../../components/forms/FormContainer"
 
 ## Get prepared
 

--- a/src/content/guides/social-security.mdx
+++ b/src/content/guides/social-security.mdx
@@ -4,7 +4,7 @@ description: Changing your name with Social Security is required to update some 
 category: social-security
 ---
 
-import { FormContainer } from "~/components/forms/FormContainer/FormContainer"
+import { FormContainer } from "#components/forms/FormContainer/FormContainer"
 
 ## Get prepared
 

--- a/src/content/guides/social-security.mdx
+++ b/src/content/guides/social-security.mdx
@@ -4,7 +4,7 @@ description: Changing your name with Social Security is required to update some 
 category: social-security
 ---
 
-import { FormContainer } from "#components/forms/FormContainer/FormContainer"
+import { FormContainer } from "../../components/forms/FormContainer/FormContainer"
 
 ## Get prepared
 

--- a/src/content/pdfs/federal/ss5-application-for-social-security-card/index.test.ts
+++ b/src/content/pdfs/federal/ss5-application-for-social-security-card/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
-import { getPdfForm } from "~/pdfs/getPdfForm";
+import { expectPdfFieldsMatch } from "#pdfs/expectPdfFieldsMatch";
+import { getPdfForm } from "#pdfs/getPdfForm";
 import ss5Application from ".";
 
 describe("SS-5 Application for Social Security Card", () => {

--- a/src/content/pdfs/federal/ss5-application-for-social-security-card/index.test.ts
+++ b/src/content/pdfs/federal/ss5-application-for-social-security-card/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { expectPdfFieldsMatch } from "../../../../pdfs/expectPdfFieldsMatch";
-import { getPdfForm } from "../../../../pdfs/getPdfForm";
+import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
+import { getPdfForm } from "~/pdfs/getPdfForm";
 import ss5Application from ".";
 
 describe("SS-5 Application for Social Security Card", () => {

--- a/src/content/pdfs/federal/ss5-application-for-social-security-card/index.ts
+++ b/src/content/pdfs/federal/ss5-application-for-social-security-card/index.ts
@@ -1,6 +1,6 @@
-import { definePdf } from "../../../../pdfs/definePdf";
-import { formatBirthplaceCountryOrState } from "../../../../utils/formatBirthplaceCountryOrState";
-import { formatDateMMDDYYYY } from "../../../../utils/formatDateMMDDYYYY";
+import { definePdf } from "~/pdfs/definePdf";
+import { formatBirthplaceCountryOrState } from "~/utils/formatBirthplaceCountryOrState";
+import { formatDateMMDDYYYY } from "~/utils/formatDateMMDDYYYY";
 import type { PdfFieldName } from "./schema";
 import pdf from "./ss5-application-for-social-security-card.pdf";
 

--- a/src/content/pdfs/federal/ss5-application-for-social-security-card/index.ts
+++ b/src/content/pdfs/federal/ss5-application-for-social-security-card/index.ts
@@ -1,6 +1,6 @@
-import { definePdf } from "~/pdfs/definePdf";
-import { formatBirthplaceCountryOrState } from "~/utils/formatBirthplaceCountryOrState";
-import { formatDateMMDDYYYY } from "~/utils/formatDateMMDDYYYY";
+import { definePdf } from "#pdfs/definePdf";
+import { formatBirthplaceCountryOrState } from "#utils/formatBirthplaceCountryOrState";
+import { formatDateMMDDYYYY } from "#utils/formatDateMMDDYYYY";
 import type { PdfFieldName } from "./schema";
 import pdf from "./ss5-application-for-social-security-card.pdf";
 

--- a/src/content/pdfs/ma/affidavit-of-indigency/index.test.ts
+++ b/src/content/pdfs/ma/affidavit-of-indigency/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { expectPdfFieldsMatch } from "../../../../pdfs/expectPdfFieldsMatch";
+import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
 import affidavitOfIndigency from ".";
 
 describe("Affidavit of Indigency", () => {

--- a/src/content/pdfs/ma/affidavit-of-indigency/index.test.ts
+++ b/src/content/pdfs/ma/affidavit-of-indigency/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
+import { expectPdfFieldsMatch } from "#pdfs/expectPdfFieldsMatch";
 import affidavitOfIndigency from ".";
 
 describe("Affidavit of Indigency", () => {

--- a/src/content/pdfs/ma/affidavit-of-indigency/index.ts
+++ b/src/content/pdfs/ma/affidavit-of-indigency/index.ts
@@ -1,5 +1,5 @@
-import { definePdf } from "../../../../pdfs/definePdf";
-import { joinNames } from "../../../../utils/joinNames";
+import { definePdf } from "~/pdfs/definePdf";
+import { joinNames } from "~/utils/joinNames";
 import pdf from "./affidavit-of-indigency.pdf";
 import type { PdfFieldName } from "./schema";
 

--- a/src/content/pdfs/ma/affidavit-of-indigency/index.ts
+++ b/src/content/pdfs/ma/affidavit-of-indigency/index.ts
@@ -1,5 +1,5 @@
-import { definePdf } from "~/pdfs/definePdf";
-import { joinNames } from "~/utils/joinNames";
+import { definePdf } from "#pdfs/definePdf";
+import { joinNames } from "#utils/joinNames";
 import pdf from "./affidavit-of-indigency.pdf";
 import type { PdfFieldName } from "./schema";
 

--- a/src/content/pdfs/ma/cjp25-petition-to-change-name-of-minor/index.test.ts
+++ b/src/content/pdfs/ma/cjp25-petition-to-change-name-of-minor/index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { FormData } from "../../../../constants/fields";
-import { expectPdfFieldsMatch } from "../../../../pdfs/expectPdfFieldsMatch";
-import { getPdfForm } from "../../../../pdfs/getPdfForm";
+import type { FormData } from "~/constants/fields";
+import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
+import { getPdfForm } from "~/pdfs/getPdfForm";
 import cjp25PetitionToChangeNameOfMinor from ".";
 
 describe("Petition to Change Name of Minor", () => {

--- a/src/content/pdfs/ma/cjp25-petition-to-change-name-of-minor/index.test.ts
+++ b/src/content/pdfs/ma/cjp25-petition-to-change-name-of-minor/index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { FormData } from "~/constants/fields";
-import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
-import { getPdfForm } from "~/pdfs/getPdfForm";
+import type { FormData } from "#constants/fields";
+import { expectPdfFieldsMatch } from "#pdfs/expectPdfFieldsMatch";
+import { getPdfForm } from "#pdfs/getPdfForm";
 import cjp25PetitionToChangeNameOfMinor from ".";
 
 describe("Petition to Change Name of Minor", () => {

--- a/src/content/pdfs/ma/cjp25-petition-to-change-name-of-minor/index.ts
+++ b/src/content/pdfs/ma/cjp25-petition-to-change-name-of-minor/index.ts
@@ -1,8 +1,8 @@
-import { definePdf } from "../../../../pdfs/definePdf";
-import { deriveCurrentAge } from "../../../../utils/deriveCurrentAge";
-import { formatDateMMDDYYYY } from "../../../../utils/formatDateMMDDYYYY";
-import { formatLanguage } from "../../../../utils/formatLanguage";
-import { joinPronouns } from "../../../../utils/joinPronouns";
+import { definePdf } from "~/pdfs/definePdf";
+import { deriveCurrentAge } from "~/utils/deriveCurrentAge";
+import { formatDateMMDDYYYY } from "~/utils/formatDateMMDDYYYY";
+import { formatLanguage } from "~/utils/formatLanguage";
+import { joinPronouns } from "~/utils/joinPronouns";
 import pdf from "./cjp25-petition-to-change-name-of-minor.pdf";
 import type { PdfFieldName } from "./schema";
 

--- a/src/content/pdfs/ma/cjp25-petition-to-change-name-of-minor/index.ts
+++ b/src/content/pdfs/ma/cjp25-petition-to-change-name-of-minor/index.ts
@@ -1,8 +1,8 @@
-import { definePdf } from "~/pdfs/definePdf";
-import { deriveCurrentAge } from "~/utils/deriveCurrentAge";
-import { formatDateMMDDYYYY } from "~/utils/formatDateMMDDYYYY";
-import { formatLanguage } from "~/utils/formatLanguage";
-import { joinPronouns } from "~/utils/joinPronouns";
+import { definePdf } from "#pdfs/definePdf";
+import { deriveCurrentAge } from "#utils/deriveCurrentAge";
+import { formatDateMMDDYYYY } from "#utils/formatDateMMDDYYYY";
+import { formatLanguage } from "#utils/formatLanguage";
+import { joinPronouns } from "#utils/joinPronouns";
 import pdf from "./cjp25-petition-to-change-name-of-minor.pdf";
 import type { PdfFieldName } from "./schema";
 

--- a/src/content/pdfs/ma/cjp27-petition-to-change-name-of-adult/index.test.ts
+++ b/src/content/pdfs/ma/cjp27-petition-to-change-name-of-adult/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "vitest";
-import type { FormData } from "~/constants/fields";
-import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
+import type { FormData } from "#constants/fields";
+import { expectPdfFieldsMatch } from "#pdfs/expectPdfFieldsMatch";
 import petitionToChangeNameOfAdult from ".";
 
 describe("CJP27 Petition to Change Name of Adult", () => {

--- a/src/content/pdfs/ma/cjp27-petition-to-change-name-of-adult/index.test.ts
+++ b/src/content/pdfs/ma/cjp27-petition-to-change-name-of-adult/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "vitest";
-import type { FormData } from "../../../../constants/fields";
-import { expectPdfFieldsMatch } from "../../../../pdfs/expectPdfFieldsMatch";
+import type { FormData } from "~/constants/fields";
+import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
 import petitionToChangeNameOfAdult from ".";
 
 describe("CJP27 Petition to Change Name of Adult", () => {

--- a/src/content/pdfs/ma/cjp27-petition-to-change-name-of-adult/index.ts
+++ b/src/content/pdfs/ma/cjp27-petition-to-change-name-of-adult/index.ts
@@ -1,7 +1,7 @@
-import { definePdf } from "../../../../pdfs/definePdf";
-import { formatDateMMDDYYYY } from "../../../../utils/formatDateMMDDYYYY";
-import { formatLanguage } from "../../../../utils/formatLanguage";
-import { joinPronouns } from "../../../../utils/joinPronouns";
+import { definePdf } from "~/pdfs/definePdf";
+import { formatDateMMDDYYYY } from "~/utils/formatDateMMDDYYYY";
+import { formatLanguage } from "~/utils/formatLanguage";
+import { joinPronouns } from "~/utils/joinPronouns";
 import pdf from "./cjp27-petition-to-change-name-of-adult.pdf";
 import type { PdfFieldName } from "./schema";
 

--- a/src/content/pdfs/ma/cjp27-petition-to-change-name-of-adult/index.ts
+++ b/src/content/pdfs/ma/cjp27-petition-to-change-name-of-adult/index.ts
@@ -1,7 +1,7 @@
-import { definePdf } from "~/pdfs/definePdf";
-import { formatDateMMDDYYYY } from "~/utils/formatDateMMDDYYYY";
-import { formatLanguage } from "~/utils/formatLanguage";
-import { joinPronouns } from "~/utils/joinPronouns";
+import { definePdf } from "#pdfs/definePdf";
+import { formatDateMMDDYYYY } from "#utils/formatDateMMDDYYYY";
+import { formatLanguage } from "#utils/formatLanguage";
+import { joinPronouns } from "#utils/joinPronouns";
 import pdf from "./cjp27-petition-to-change-name-of-adult.pdf";
 import type { PdfFieldName } from "./schema";
 

--- a/src/content/pdfs/ma/cjp34-cori-and-wms-release-request/index.test.ts
+++ b/src/content/pdfs/ma/cjp34-cori-and-wms-release-request/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
+import { expectPdfFieldsMatch } from "#pdfs/expectPdfFieldsMatch";
 import coriAndWmsReleaseRequest from ".";
 
 describe("CJP34 CORI and WMS Release Request", () => {

--- a/src/content/pdfs/ma/cjp34-cori-and-wms-release-request/index.test.ts
+++ b/src/content/pdfs/ma/cjp34-cori-and-wms-release-request/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { expectPdfFieldsMatch } from "../../../../pdfs/expectPdfFieldsMatch";
+import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
 import coriAndWmsReleaseRequest from ".";
 
 describe("CJP34 CORI and WMS Release Request", () => {

--- a/src/content/pdfs/ma/cjp34-cori-and-wms-release-request/index.ts
+++ b/src/content/pdfs/ma/cjp34-cori-and-wms-release-request/index.ts
@@ -1,6 +1,6 @@
-import { definePdf } from "../../../../pdfs/definePdf";
-import { formatDateMMDDYYYY } from "../../../../utils/formatDateMMDDYYYY";
-import { joinNames } from "../../../../utils/joinNames";
+import { definePdf } from "~/pdfs/definePdf";
+import { formatDateMMDDYYYY } from "~/utils/formatDateMMDDYYYY";
+import { joinNames } from "~/utils/joinNames";
 import pdf from "./cjp34-cori-and-wms-release-request.pdf";
 import type { PdfFieldName } from "./schema";
 

--- a/src/content/pdfs/ma/cjp34-cori-and-wms-release-request/index.ts
+++ b/src/content/pdfs/ma/cjp34-cori-and-wms-release-request/index.ts
@@ -1,6 +1,6 @@
-import { definePdf } from "~/pdfs/definePdf";
-import { formatDateMMDDYYYY } from "~/utils/formatDateMMDDYYYY";
-import { joinNames } from "~/utils/joinNames";
+import { definePdf } from "#pdfs/definePdf";
+import { formatDateMMDDYYYY } from "#utils/formatDateMMDDYYYY";
+import { joinNames } from "#utils/joinNames";
 import pdf from "./cjp34-cori-and-wms-release-request.pdf";
 import type { PdfFieldName } from "./schema";
 

--- a/src/content/pdfs/ri/background-check-authorization-of-release/index.test.ts
+++ b/src/content/pdfs/ri/background-check-authorization-of-release/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { FormData } from "~/constants/fields";
-import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
+import type { FormData } from "#constants/fields";
+import { expectPdfFieldsMatch } from "#pdfs/expectPdfFieldsMatch";
 import backgroundCheckAuthorizationOfRelease from ".";
 
 describe("Background Check Authorization of Release", () => {

--- a/src/content/pdfs/ri/background-check-authorization-of-release/index.test.ts
+++ b/src/content/pdfs/ri/background-check-authorization-of-release/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { FormData } from "../../../../constants/fields";
-import { expectPdfFieldsMatch } from "../../../../pdfs/expectPdfFieldsMatch";
+import type { FormData } from "~/constants/fields";
+import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
 import backgroundCheckAuthorizationOfRelease from ".";
 
 describe("Background Check Authorization of Release", () => {

--- a/src/content/pdfs/ri/background-check-authorization-of-release/index.ts
+++ b/src/content/pdfs/ri/background-check-authorization-of-release/index.ts
@@ -1,7 +1,7 @@
-import { definePdf } from "~/pdfs/definePdf";
-import { formatAddress } from "~/utils/formatAddress";
-import { formatDateMMDDYYYY } from "~/utils/formatDateMMDDYYYY";
-import { joinNames } from "~/utils/joinNames";
+import { definePdf } from "#pdfs/definePdf";
+import { formatAddress } from "#utils/formatAddress";
+import { formatDateMMDDYYYY } from "#utils/formatDateMMDDYYYY";
+import { joinNames } from "#utils/joinNames";
 import pdf from "./background-check-authorization-of-release.pdf";
 import type { PdfFieldName } from "./schema";
 

--- a/src/content/pdfs/ri/background-check-authorization-of-release/index.ts
+++ b/src/content/pdfs/ri/background-check-authorization-of-release/index.ts
@@ -1,7 +1,7 @@
-import { definePdf } from "../../../../pdfs/definePdf";
-import { formatAddress } from "../../../../utils/formatAddress";
-import { formatDateMMDDYYYY } from "../../../../utils/formatDateMMDDYYYY";
-import { joinNames } from "../../../../utils/joinNames";
+import { definePdf } from "~/pdfs/definePdf";
+import { formatAddress } from "~/utils/formatAddress";
+import { formatDateMMDDYYYY } from "~/utils/formatDateMMDDYYYY";
+import { joinNames } from "~/utils/joinNames";
 import pdf from "./background-check-authorization-of-release.pdf";
 import type { PdfFieldName } from "./schema";
 

--- a/src/content/pdfs/ri/pc8.1-change-of-name/index.test.ts
+++ b/src/content/pdfs/ri/pc8.1-change-of-name/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "vitest";
-import type { FormData } from "../../../../constants/fields";
-import { expectPdfFieldsMatch } from "../../../../pdfs/expectPdfFieldsMatch";
+import type { FormData } from "~/constants/fields";
+import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
 import pc81ChangeOfName from ".";
 
 describe("Change of Name", () => {

--- a/src/content/pdfs/ri/pc8.1-change-of-name/index.test.ts
+++ b/src/content/pdfs/ri/pc8.1-change-of-name/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "vitest";
-import type { FormData } from "~/constants/fields";
-import { expectPdfFieldsMatch } from "~/pdfs/expectPdfFieldsMatch";
+import type { FormData } from "#constants/fields";
+import { expectPdfFieldsMatch } from "#pdfs/expectPdfFieldsMatch";
 import pc81ChangeOfName from ".";
 
 describe("Change of Name", () => {

--- a/src/content/pdfs/ri/pc8.1-change-of-name/index.ts
+++ b/src/content/pdfs/ri/pc8.1-change-of-name/index.ts
@@ -1,8 +1,8 @@
-import { definePdf } from "../../../../pdfs/definePdf";
-import { formatBirthplaceCountryOrState } from "../../../../utils/formatBirthplaceCountryOrState";
-import { formatDateMMDDYYYY } from "../../../../utils/formatDateMMDDYYYY";
-import { joinNames } from "../../../../utils/joinNames";
-import { joinParts } from "../../../../utils/joinParts";
+import { definePdf } from "~/pdfs/definePdf";
+import { formatBirthplaceCountryOrState } from "~/utils/formatBirthplaceCountryOrState";
+import { formatDateMMDDYYYY } from "~/utils/formatDateMMDDYYYY";
+import { joinNames } from "~/utils/joinNames";
+import { joinParts } from "~/utils/joinParts";
 import pdf from "./pc8.1-change-of-name.pdf";
 import type { PdfFieldName } from "./schema";
 

--- a/src/content/pdfs/ri/pc8.1-change-of-name/index.ts
+++ b/src/content/pdfs/ri/pc8.1-change-of-name/index.ts
@@ -1,8 +1,8 @@
-import { definePdf } from "~/pdfs/definePdf";
-import { formatBirthplaceCountryOrState } from "~/utils/formatBirthplaceCountryOrState";
-import { formatDateMMDDYYYY } from "~/utils/formatDateMMDDYYYY";
-import { joinNames } from "~/utils/joinNames";
-import { joinParts } from "~/utils/joinParts";
+import { definePdf } from "#pdfs/definePdf";
+import { formatBirthplaceCountryOrState } from "#utils/formatBirthplaceCountryOrState";
+import { formatDateMMDDYYYY } from "#utils/formatDateMMDDYYYY";
+import { joinNames } from "#utils/joinNames";
+import { joinParts } from "#utils/joinParts";
 import pdf from "./pc8.1-change-of-name.pdf";
 import type { PdfFieldName } from "./schema";
 

--- a/src/content/posts/becoming-sloane/index.mdx
+++ b/src/content/posts/becoming-sloane/index.mdx
@@ -8,7 +8,7 @@ image:
   alt: "The text 'Becoming Sloane' is rendered in a variety of fonts as if clipped from different newspaper and magazine pages."
 ---
 
-import { YouTube } from "~/components/common/YouTube";
+import { YouTube } from "#components/common/YouTube";
 
 On May 15, 2025, in Somerville, MA, the Massachusetts Transgender Political Coalition held the 15th Annual Professionals for Trans Rights. At the event, MTPC aired the following interview, Becoming Sloane. Directed and produced by Nayeli Mzîn.
 

--- a/src/content/posts/becoming-sloane/index.mdx
+++ b/src/content/posts/becoming-sloane/index.mdx
@@ -8,7 +8,7 @@ image:
   alt: "The text 'Becoming Sloane' is rendered in a variety of fonts as if clipped from different newspaper and magazine pages."
 ---
 
-import { YouTube } from "../../../components/common/YouTube";
+import { YouTube } from "../../../../components/common/YouTube";
 
 On May 15, 2025, in Somerville, MA, the Massachusetts Transgender Political Coalition held the 15th Annual Professionals for Trans Rights. At the event, MTPC aired the following interview, Becoming Sloane. Directed and produced by Nayeli Mzîn.
 

--- a/src/content/posts/becoming-sloane/index.mdx
+++ b/src/content/posts/becoming-sloane/index.mdx
@@ -8,7 +8,7 @@ image:
   alt: "The text 'Becoming Sloane' is rendered in a variety of fonts as if clipped from different newspaper and magazine pages."
 ---
 
-import { YouTube } from "../../../components/common/YouTube";
+import { YouTube } from "~/components/common/YouTube";
 
 On May 15, 2025, in Somerville, MA, the Massachusetts Transgender Political Coalition held the 15th Annual Professionals for Trans Rights. At the event, MTPC aired the following interview, Becoming Sloane. Directed and produced by Nayeli Mzîn.
 

--- a/src/content/posts/becoming-sloane/index.mdx
+++ b/src/content/posts/becoming-sloane/index.mdx
@@ -8,7 +8,7 @@ image:
   alt: "The text 'Becoming Sloane' is rendered in a variety of fonts as if clipped from different newspaper and magazine pages."
 ---
 
-import { YouTube } from "../../../../components/common/YouTube";
+import { YouTube } from "../../../components/common/YouTube";
 
 On May 15, 2025, in Somerville, MA, the Massachusetts Transgender Political Coalition held the 15th Annual Professionals for Trans Rights. At the event, MTPC aired the following interview, Becoming Sloane. Directed and produced by Nayeli Mzîn.
 

--- a/src/content/posts/becoming-sloane/index.mdx
+++ b/src/content/posts/becoming-sloane/index.mdx
@@ -8,7 +8,7 @@ image:
   alt: "The text 'Becoming Sloane' is rendered in a variety of fonts as if clipped from different newspaper and magazine pages."
 ---
 
-import { YouTube } from "#components/common/YouTube";
+import { YouTube } from "../../../components/common/YouTube";
 
 On May 15, 2025, in Somerville, MA, the Massachusetts Transgender Political Coalition held the 15th Annual Professionals for Trans Rights. At the event, MTPC aired the following interview, Becoming Sloane. Directed and produced by Nayeli Mzîn.
 

--- a/src/content/queries/guides.ts
+++ b/src/content/queries/guides.ts
@@ -1,6 +1,6 @@
 import type { CollectionEntry } from "astro:content";
 import { getCollection, getEntry } from "astro:content";
-import { GUIDE_CATEGORY_ORDER } from "../../constants/guides";
+import { GUIDE_CATEGORY_ORDER } from "~/constants/guides";
 
 const categoryRank = (id: string) => {
   const i = GUIDE_CATEGORY_ORDER.indexOf(id);

--- a/src/content/queries/guides.ts
+++ b/src/content/queries/guides.ts
@@ -1,6 +1,6 @@
 import type { CollectionEntry } from "astro:content";
 import { getCollection, getEntry } from "astro:content";
-import { GUIDE_CATEGORY_ORDER } from "~/constants/guides";
+import { GUIDE_CATEGORY_ORDER } from "#constants/guides";
 
 const categoryRank = (id: string) => {
   const i = GUIDE_CATEGORY_ORDER.indexOf(id);

--- a/src/forms/__tests__/createFormSubmitHandler.test.ts
+++ b/src/forms/__tests__/createFormSubmitHandler.test.ts
@@ -1,8 +1,8 @@
 import type { SubmitEvent } from "react";
 import type { FieldValues, UseFormReturn } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { FormConfig } from "../../constants/forms";
-import type { PDFId } from "../../constants/pdf";
+import type { FormConfig } from "~/constants/forms";
+import type { PDFId } from "~/constants/pdf";
 import { downloadMergedPdf } from "../../pdfs/downloadMergedPdf";
 import { loadPdfs } from "../../pdfs/loadPdfs";
 import { createFormSubmitHandler } from "../createFormSubmitHandler";

--- a/src/forms/__tests__/createFormSubmitHandler.test.ts
+++ b/src/forms/__tests__/createFormSubmitHandler.test.ts
@@ -1,8 +1,8 @@
 import type { SubmitEvent } from "react";
 import type { FieldValues, UseFormReturn } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { FormConfig } from "~/constants/forms";
-import type { PDFId } from "~/constants/pdf";
+import type { FormConfig } from "#constants/forms";
+import type { PDFId } from "#constants/pdf";
 import { downloadMergedPdf } from "../../pdfs/downloadMergedPdf";
 import { loadPdfs } from "../../pdfs/loadPdfs";
 import { createFormSubmitHandler } from "../createFormSubmitHandler";

--- a/src/forms/__tests__/useFormData.test.ts
+++ b/src/forms/__tests__/useFormData.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { FormConfig } from "~/constants/forms";
+import type { FormConfig } from "#constants/forms";
 import * as database from "../../db/database";
 import { useFormData } from "../useFormData";
 

--- a/src/forms/__tests__/useFormData.test.ts
+++ b/src/forms/__tests__/useFormData.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { FormConfig } from "../../constants/forms";
+import type { FormConfig } from "~/constants/forms";
 import * as database from "../../db/database";
 import { useFormData } from "../useFormData";
 

--- a/src/pages/api/__tests__/feedback.test.ts
+++ b/src/pages/api/__tests__/feedback.test.ts
@@ -1,7 +1,7 @@
 import { env as cfWorkersEnv } from "cloudflare:workers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { isRateLimited } from "~/utils/rateLimitByIp";
+import { isRateLimited } from "#utils/rateLimitByIp";
 import { POST } from "../feedback";
 
 /** Same object `feedback.ts` imports; widened so tests can clear optional bindings. */
@@ -10,7 +10,7 @@ const env = cfWorkersEnv as {
   RESEND_API_KEY: string | undefined;
 };
 
-vi.mock("~/utils/rateLimitByIp", () => ({
+vi.mock("#utils/rateLimitByIp", () => ({
   isRateLimited: vi.fn().mockResolvedValue(false),
 }));
 

--- a/src/pages/api/__tests__/feedback.test.ts
+++ b/src/pages/api/__tests__/feedback.test.ts
@@ -1,7 +1,7 @@
 import { env as cfWorkersEnv } from "cloudflare:workers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { isRateLimited } from "../../../utils/rateLimitByIp";
+import { isRateLimited } from "~/utils/rateLimitByIp";
 import { POST } from "../feedback";
 
 /** Same object `feedback.ts` imports; widened so tests can clear optional bindings. */
@@ -10,7 +10,7 @@ const env = cfWorkersEnv as {
   RESEND_API_KEY: string | undefined;
 };
 
-vi.mock("../../../utils/rateLimitByIp", () => ({
+vi.mock("~/utils/rateLimitByIp", () => ({
   isRateLimited: vi.fn().mockResolvedValue(false),
 }));
 

--- a/src/pages/api/feedback.ts
+++ b/src/pages/api/feedback.ts
@@ -7,8 +7,8 @@ import {
   FORM_FEEDBACK_SENTIMENT,
   FORM_SLUGS,
   type FormFeedbackSentiment,
-} from "../../constants/forms";
-import { isRateLimited } from "../../utils/rateLimitByIp";
+} from "~/constants/forms";
+import { isRateLimited } from "~/utils/rateLimitByIp";
 
 const PRODUCTION_ORIGIN = "https://namesake.fyi";
 const ALLOWED_ORIGINS = [PRODUCTION_ORIGIN, "http://localhost:4321"];

--- a/src/pages/api/feedback.ts
+++ b/src/pages/api/feedback.ts
@@ -7,8 +7,8 @@ import {
   FORM_FEEDBACK_SENTIMENT,
   FORM_SLUGS,
   type FormFeedbackSentiment,
-} from "~/constants/forms";
-import { isRateLimited } from "~/utils/rateLimitByIp";
+} from "#constants/forms";
+import { isRateLimited } from "#utils/rateLimitByIp";
 
 const PRODUCTION_ORIGIN = "https://namesake.fyi";
 const ALLOWED_ORIGINS = [PRODUCTION_ORIGIN, "http://localhost:4321"];

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -6,8 +6,8 @@ import {
   getEntry,
   render,
 } from "astro:content";
-import TableOfContents from "~/components/TableOfContents.astro";
-import ProseLayout from "~/layouts/ProseLayout.astro";
+import TableOfContents from "#components/TableOfContents.astro";
+import ProseLayout from "#layouts/ProseLayout.astro";
 
 export async function getStaticPaths() {
   const posts = await getCollection("posts");

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,5 +1,4 @@
 ---
-
 import { Image } from "astro:assets";
 import {
   type CollectionEntry,
@@ -7,8 +6,8 @@ import {
   getEntry,
   render,
 } from "astro:content";
-import TableOfContents from "../../components/TableOfContents.astro";
-import ProseLayout from "../../layouts/ProseLayout.astro";
+import TableOfContents from "~/components/TableOfContents.astro";
+import ProseLayout from "~/layouts/ProseLayout.astro";
 
 export async function getStaticPaths() {
   const posts = await getCollection("posts");
@@ -86,17 +85,22 @@ const ogAlt = post.data.image?.alt ?? post.data.title;
             <div class="content">
               <strong>{author.data.name}</strong>
               <p>{author.data.bio}</p>
-              {author.data.socialLinks && author.data.socialLinks.length > 0 && (
-                <ul class="social">
-                  {author.data.socialLinks.map((link) => (
-                    <li>
-                      <a href={link.url} target="_blank" rel="noopener noreferrer">
-                        {link.name}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              )}
+              {author.data.socialLinks &&
+                author.data.socialLinks.length > 0 && (
+                  <ul class="social">
+                    {author.data.socialLinks.map((link) => (
+                      <li>
+                        <a
+                          href={link.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {link.name}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
             </div>
           </div>
         ))}

--- a/src/pages/blog/[slug].png.ts
+++ b/src/pages/blog/[slug].png.ts
@@ -1,6 +1,6 @@
 import { type CollectionEntry, getCollection } from "astro:content";
 import type { APIRoute, GetStaticPaths } from "astro";
-import { createOgImageResponse } from "~/utils/createOgImageResponse";
+import { createOgImageResponse } from "#utils/createOgImageResponse";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const posts = await getCollection("posts");

--- a/src/pages/blog/[slug].png.ts
+++ b/src/pages/blog/[slug].png.ts
@@ -1,6 +1,6 @@
 import { type CollectionEntry, getCollection } from "astro:content";
 import type { APIRoute, GetStaticPaths } from "astro";
-import { createOgImageResponse } from "../../utils/createOgImageResponse";
+import { createOgImageResponse } from "~/utils/createOgImageResponse";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const posts = await getCollection("posts");

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,8 +1,8 @@
 ---
 import { getCollection } from "astro:content";
-import ArticleLink from "~/components/ArticleLink.astro";
-import PageHeader from "~/components/PageHeader.astro";
-import BaseLayout from "~/layouts/BaseLayout.astro";
+import ArticleLink from "#components/ArticleLink.astro";
+import PageHeader from "#components/PageHeader.astro";
+import BaseLayout from "#layouts/BaseLayout.astro";
 
 const [allPosts, allAuthors] = await Promise.all([
   getCollection("posts"),

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,9 +1,8 @@
 ---
-
 import { getCollection } from "astro:content";
-import ArticleLink from "../../components/ArticleLink.astro";
-import PageHeader from "../../components/PageHeader.astro";
-import BaseLayout from "../../layouts/BaseLayout.astro";
+import ArticleLink from "~/components/ArticleLink.astro";
+import PageHeader from "~/components/PageHeader.astro";
+import BaseLayout from "~/layouts/BaseLayout.astro";
 
 const [allPosts, allAuthors] = await Promise.all([
   getCollection("posts"),

--- a/src/pages/brand-assets/_components/Swatches.astro
+++ b/src/pages/brand-assets/_components/Swatches.astro
@@ -1,5 +1,5 @@
 ---
-import { COLORS } from "~/constants/colors";
+import { COLORS } from "#constants/colors";
 ---
 
 <ul class="swatches">

--- a/src/pages/brand-assets/_components/Swatches.astro
+++ b/src/pages/brand-assets/_components/Swatches.astro
@@ -1,5 +1,5 @@
 ---
-import { COLORS } from "../../../constants/colors";
+import { COLORS } from "~/constants/colors";
 ---
 
 <ul class="swatches">

--- a/src/pages/brand-assets/index.astro
+++ b/src/pages/brand-assets/index.astro
@@ -1,7 +1,7 @@
 ---
 import { RiDownloadLine } from "@remixicon/react";
-import PageHeader from "~/components/PageHeader.astro";
-import BaseLayout from "~/layouts/BaseLayout.astro";
+import PageHeader from "#components/PageHeader.astro";
+import BaseLayout from "#layouts/BaseLayout.astro";
 import BrandAssetCard from "./_components/BrandAssetCard.astro";
 import Swatches from "./_components/Swatches.astro";
 ---

--- a/src/pages/brand-assets/index.astro
+++ b/src/pages/brand-assets/index.astro
@@ -1,8 +1,7 @@
 ---
-
 import { RiDownloadLine } from "@remixicon/react";
-import PageHeader from "../../components/PageHeader.astro";
-import BaseLayout from "../../layouts/BaseLayout.astro";
+import PageHeader from "~/components/PageHeader.astro";
+import BaseLayout from "~/layouts/BaseLayout.astro";
 import BrandAssetCard from "./_components/BrandAssetCard.astro";
 import Swatches from "./_components/Swatches.astro";
 ---

--- a/src/pages/directory/index.astro
+++ b/src/pages/directory/index.astro
@@ -8,14 +8,10 @@ import {
   RiPhoneLine,
   RiVerifiedBadgeFill,
 } from "@remixicon/react";
-import PageHeader from "../../components/PageHeader.astro";
-import {
-  SERVICE_LABELS,
-  SERVICES,
-  type Service,
-} from "../../constants/services";
-import BaseLayout from "../../layouts/BaseLayout.astro";
-import { formatCleanUrl } from "../../utils/formatCleanUrl";
+import PageHeader from "~/components/PageHeader.astro";
+import { SERVICE_LABELS, SERVICES, type Service } from "~/constants/services";
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import { formatCleanUrl } from "~/utils/formatCleanUrl";
 
 const stateParam = Astro.url.searchParams.get("state");
 const serviceParam = Astro.url.searchParams.get("service");

--- a/src/pages/directory/index.astro
+++ b/src/pages/directory/index.astro
@@ -8,10 +8,10 @@ import {
   RiPhoneLine,
   RiVerifiedBadgeFill,
 } from "@remixicon/react";
-import PageHeader from "~/components/PageHeader.astro";
-import { SERVICE_LABELS, SERVICES, type Service } from "~/constants/services";
-import BaseLayout from "~/layouts/BaseLayout.astro";
-import { formatCleanUrl } from "~/utils/formatCleanUrl";
+import PageHeader from "#components/PageHeader.astro";
+import { SERVICE_LABELS, SERVICES, type Service } from "#constants/services";
+import BaseLayout from "#layouts/BaseLayout.astro";
+import { formatCleanUrl } from "#utils/formatCleanUrl";
 
 const stateParam = Astro.url.searchParams.get("state");
 const serviceParam = Astro.url.searchParams.get("service");

--- a/src/pages/forms/[slug].astro
+++ b/src/pages/forms/[slug].astro
@@ -1,9 +1,9 @@
 ---
 import { type CollectionEntry, getCollection } from "astro:content";
-import { FormContainer } from "~/components/forms/FormContainer/FormContainer";
-import type { FormSlug } from "~/constants/forms";
-import { getFormConfig } from "~/forms/getFormConfig";
-import BaseLayout from "~/layouts/BaseLayout.astro";
+import { FormContainer } from "#components/forms/FormContainer/FormContainer";
+import type { FormSlug } from "#constants/forms";
+import { getFormConfig } from "#forms/getFormConfig";
+import BaseLayout from "#layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
   const forms = await getCollection("forms");

--- a/src/pages/forms/[slug].astro
+++ b/src/pages/forms/[slug].astro
@@ -1,10 +1,9 @@
 ---
-
 import { type CollectionEntry, getCollection } from "astro:content";
-import { FormContainer } from "../../components/forms/FormContainer/FormContainer";
-import type { FormSlug } from "../../constants/forms";
-import { getFormConfig } from "../../forms/getFormConfig";
-import BaseLayout from "../../layouts/BaseLayout.astro";
+import { FormContainer } from "~/components/forms/FormContainer/FormContainer";
+import type { FormSlug } from "~/constants/forms";
+import { getFormConfig } from "~/forms/getFormConfig";
+import BaseLayout from "~/layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
   const forms = await getCollection("forms");

--- a/src/pages/forms/[slug].astro
+++ b/src/pages/forms/[slug].astro
@@ -1,9 +1,9 @@
 ---
 import { type CollectionEntry, getCollection } from "astro:content";
-import { FormContainer } from "#components/forms/FormContainer/FormContainer";
 import type { FormSlug } from "#constants/forms";
 import { getFormConfig } from "#forms/getFormConfig";
 import BaseLayout from "#layouts/BaseLayout.astro";
+import { FormContainer } from "../../components/forms/FormContainer";
 
 export async function getStaticPaths() {
   const forms = await getCollection("forms");

--- a/src/pages/forms/[slug].png.ts
+++ b/src/pages/forms/[slug].png.ts
@@ -1,6 +1,6 @@
 import { type CollectionEntry, getCollection } from "astro:content";
 import type { APIRoute, GetStaticPaths } from "astro";
-import { createOgImageResponse } from "../../utils/createOgImageResponse";
+import { createOgImageResponse } from "~/utils/createOgImageResponse";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const forms = await getCollection("forms");

--- a/src/pages/forms/[slug].png.ts
+++ b/src/pages/forms/[slug].png.ts
@@ -1,6 +1,6 @@
 import { type CollectionEntry, getCollection } from "astro:content";
 import type { APIRoute, GetStaticPaths } from "astro";
-import { createOgImageResponse } from "~/utils/createOgImageResponse";
+import { createOgImageResponse } from "#utils/createOgImageResponse";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const forms = await getCollection("forms");

--- a/src/pages/forms/index.astro
+++ b/src/pages/forms/index.astro
@@ -1,12 +1,12 @@
 ---
 import { getCollection } from "astro:content";
-import FormLink from "../../components/FormLink.astro";
-import PageHeader from "../../components/PageHeader.astro";
-import type { FormSlug } from "../../constants/forms";
-import { getFormConfig } from "../../forms/getFormConfig";
-import { getFormPdfMetadata } from "../../forms/getFormPdfMetadata";
-import BaseLayout from "../../layouts/BaseLayout.astro";
-import { formatTimeEstimate } from "../../utils/formatTimeEstimate";
+import FormLink from "~/components/FormLink.astro";
+import PageHeader from "~/components/PageHeader.astro";
+import type { FormSlug } from "~/constants/forms";
+import { getFormConfig } from "~/forms/getFormConfig";
+import { getFormPdfMetadata } from "~/forms/getFormPdfMetadata";
+import BaseLayout from "~/layouts/BaseLayout.astro";
+import { formatTimeEstimate } from "~/utils/formatTimeEstimate";
 
 const allForms = await getCollection("forms", ({ data }) => !data.unlisted);
 

--- a/src/pages/forms/index.astro
+++ b/src/pages/forms/index.astro
@@ -1,12 +1,12 @@
 ---
 import { getCollection } from "astro:content";
-import FormLink from "~/components/FormLink.astro";
-import PageHeader from "~/components/PageHeader.astro";
-import type { FormSlug } from "~/constants/forms";
-import { getFormConfig } from "~/forms/getFormConfig";
-import { getFormPdfMetadata } from "~/forms/getFormPdfMetadata";
-import BaseLayout from "~/layouts/BaseLayout.astro";
-import { formatTimeEstimate } from "~/utils/formatTimeEstimate";
+import FormLink from "#components/FormLink.astro";
+import PageHeader from "#components/PageHeader.astro";
+import type { FormSlug } from "#constants/forms";
+import { getFormConfig } from "#forms/getFormConfig";
+import { getFormPdfMetadata } from "#forms/getFormPdfMetadata";
+import BaseLayout from "#layouts/BaseLayout.astro";
+import { formatTimeEstimate } from "#utils/formatTimeEstimate";
 
 const allForms = await getCollection("forms", ({ data }) => !data.unlisted);
 

--- a/src/pages/guides/[...slug].astro
+++ b/src/pages/guides/[...slug].astro
@@ -1,10 +1,10 @@
 ---
 import { getCollection, getEntry, render } from "astro:content";
-import type { BreadcrumbItem } from "~/components/Breadcrumbs.astro";
-import GuideFooter from "~/components/GuideFooter.astro";
-import StubBanner from "~/components/StubBanner.astro";
-import TableOfContents from "~/components/TableOfContents.astro";
-import ProseLayout from "~/layouts/ProseLayout.astro";
+import type { BreadcrumbItem } from "#components/Breadcrumbs.astro";
+import GuideFooter from "#components/GuideFooter.astro";
+import StubBanner from "#components/StubBanner.astro";
+import TableOfContents from "#components/TableOfContents.astro";
+import ProseLayout from "#layouts/ProseLayout.astro";
 
 export async function getStaticPaths() {
   const guides = await getCollection("guides", ({ data }) => !data.unlisted);

--- a/src/pages/guides/[...slug].astro
+++ b/src/pages/guides/[...slug].astro
@@ -1,10 +1,10 @@
 ---
 import { getCollection, getEntry, render } from "astro:content";
-import type { BreadcrumbItem } from "../../components/Breadcrumbs.astro";
-import GuideFooter from "../../components/GuideFooter.astro";
-import StubBanner from "../../components/StubBanner.astro";
-import TableOfContents from "../../components/TableOfContents.astro";
-import ProseLayout from "../../layouts/ProseLayout.astro";
+import type { BreadcrumbItem } from "~/components/Breadcrumbs.astro";
+import GuideFooter from "~/components/GuideFooter.astro";
+import StubBanner from "~/components/StubBanner.astro";
+import TableOfContents from "~/components/TableOfContents.astro";
+import ProseLayout from "~/layouts/ProseLayout.astro";
 
 export async function getStaticPaths() {
   const guides = await getCollection("guides", ({ data }) => !data.unlisted);

--- a/src/pages/guides/[...slug].png.ts
+++ b/src/pages/guides/[...slug].png.ts
@@ -1,6 +1,6 @@
 import { type CollectionEntry, getCollection } from "astro:content";
 import type { APIRoute, GetStaticPaths } from "astro";
-import { createOgImageResponse } from "~/utils/createOgImageResponse";
+import { createOgImageResponse } from "#utils/createOgImageResponse";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const guides = await getCollection("guides");

--- a/src/pages/guides/[...slug].png.ts
+++ b/src/pages/guides/[...slug].png.ts
@@ -1,6 +1,6 @@
 import { type CollectionEntry, getCollection } from "astro:content";
 import type { APIRoute, GetStaticPaths } from "astro";
-import { createOgImageResponse } from "../../utils/createOgImageResponse";
+import { createOgImageResponse } from "~/utils/createOgImageResponse";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const guides = await getCollection("guides");

--- a/src/pages/guides/[state].astro
+++ b/src/pages/guides/[state].astro
@@ -1,8 +1,8 @@
 ---
-import type { BreadcrumbItem } from "~/components/Breadcrumbs.astro";
-import GuideLinkGroup from "~/components/GuideLinkGroup.astro";
-import PageHeader from "~/components/PageHeader.astro";
-import BaseLayout from "~/layouts/BaseLayout.astro";
+import type { BreadcrumbItem } from "#components/Breadcrumbs.astro";
+import GuideLinkGroup from "#components/GuideLinkGroup.astro";
+import PageHeader from "#components/PageHeader.astro";
+import BaseLayout from "#layouts/BaseLayout.astro";
 import { getGuidesByState } from "../../content/queries/guides";
 
 export async function getStaticPaths() {

--- a/src/pages/guides/[state].astro
+++ b/src/pages/guides/[state].astro
@@ -1,9 +1,9 @@
 ---
-import type { BreadcrumbItem } from "../../components/Breadcrumbs.astro";
-import GuideLinkGroup from "../../components/GuideLinkGroup.astro";
-import PageHeader from "../../components/PageHeader.astro";
+import type { BreadcrumbItem } from "~/components/Breadcrumbs.astro";
+import GuideLinkGroup from "~/components/GuideLinkGroup.astro";
+import PageHeader from "~/components/PageHeader.astro";
+import BaseLayout from "~/layouts/BaseLayout.astro";
 import { getGuidesByState } from "../../content/queries/guides";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
   const { guidesByState } = await getGuidesByState();

--- a/src/pages/guides/index.astro
+++ b/src/pages/guides/index.astro
@@ -1,8 +1,8 @@
 ---
-import GuideLinkGroup from "../../components/GuideLinkGroup.astro";
-import PageHeader from "../../components/PageHeader.astro";
+import GuideLinkGroup from "~/components/GuideLinkGroup.astro";
+import PageHeader from "~/components/PageHeader.astro";
+import BaseLayout from "~/layouts/BaseLayout.astro";
 import { getGuidesByState } from "../../content/queries/guides";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 
 const { generalGuides, guidesByState } = await getGuidesByState();
 ---

--- a/src/pages/guides/index.astro
+++ b/src/pages/guides/index.astro
@@ -1,7 +1,7 @@
 ---
-import GuideLinkGroup from "~/components/GuideLinkGroup.astro";
-import PageHeader from "~/components/PageHeader.astro";
-import BaseLayout from "~/layouts/BaseLayout.astro";
+import GuideLinkGroup from "#components/GuideLinkGroup.astro";
+import PageHeader from "#components/PageHeader.astro";
+import BaseLayout from "#layouts/BaseLayout.astro";
 import { getGuidesByState } from "../../content/queries/guides";
 
 const { generalGuides, guidesByState } = await getGuidesByState();

--- a/src/utils/__tests__/formatBirthplaceCountryOrState.test.ts
+++ b/src/utils/__tests__/formatBirthplaceCountryOrState.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { COUNTRIES } from "~/constants/countries";
-import { JURISDICTIONS } from "~/constants/jurisdictions";
+import { COUNTRIES } from "#constants/countries";
+import { JURISDICTIONS } from "#constants/jurisdictions";
 import { formatBirthplaceCountryOrState } from "../formatBirthplaceCountryOrState";
 
 describe("formatBirthplaceCountryOrState", () => {

--- a/src/utils/__tests__/formatBirthplaceCountryOrState.test.ts
+++ b/src/utils/__tests__/formatBirthplaceCountryOrState.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { COUNTRIES } from "../../constants/countries";
-import { JURISDICTIONS } from "../../constants/jurisdictions";
+import { COUNTRIES } from "~/constants/countries";
+import { JURISDICTIONS } from "~/constants/jurisdictions";
 import { formatBirthplaceCountryOrState } from "../formatBirthplaceCountryOrState";
 
 describe("formatBirthplaceCountryOrState", () => {

--- a/src/utils/__tests__/formatTotalCosts.test.ts
+++ b/src/utils/__tests__/formatTotalCosts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { FormCost } from "../../constants/forms";
+import type { FormCost } from "~/constants/forms";
 import { formatTotalCosts } from "../formatTotalCosts";
 
 describe("formatTotalCosts", () => {

--- a/src/utils/__tests__/formatTotalCosts.test.ts
+++ b/src/utils/__tests__/formatTotalCosts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { FormCost } from "~/constants/forms";
+import type { FormCost } from "#constants/forms";
 import { formatTotalCosts } from "../formatTotalCosts";
 
 describe("formatTotalCosts", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,10 @@
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
     "allowJs": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "jsxImportSource": "react",
-    "paths": {
-      "~/*": ["./src/*"]
-    },
     "types": ["./worker-configuration.d.ts", "node"],
     "verbatimModuleSyntax": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
     "allowJs": true,
     "jsx": "react-jsx",
     "jsxImportSource": "react",
+    "paths": {
+      "~/*": ["./src/*"]
+    },
     "types": ["./worker-configuration.d.ts", "node"],
     "verbatimModuleSyntax": true
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import {
   configDefaults,
   coverageConfigDefaults,
@@ -12,9 +11,6 @@ export default defineConfig({
     clearMocks: true,
     include: ["src/**/*.test.{ts,tsx}"],
     exclude: [...configDefaults.exclude, "src/**/*.spec.ts"],
-    alias: {
-      "~": path.resolve(__dirname, "src"),
-    },
     setupFiles: ["./src/vitest.setup.ts"],
     environment: "jsdom",
     coverage: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   configDefaults,
   coverageConfigDefaults,
@@ -11,6 +12,9 @@ export default defineConfig({
     clearMocks: true,
     include: ["src/**/*.test.{ts,tsx}"],
     exclude: [...configDefaults.exclude, "src/**/*.spec.ts"],
+    alias: {
+      "~": path.resolve(__dirname, "src"),
+    },
     setupFiles: ["./src/vitest.setup.ts"],
     environment: "jsdom",
     coverage: {


### PR DESCRIPTION
Replace lengthy relative path imports like `../../../..` with `#` for accessing the `src` folder.

Uses [subpath imports](https://medium.com/better-programming/the-native-way-to-configure-path-aliases-in-frontend-projects-5db70f19a6e0) instead of TypeScript path aliases for easier compatibility with Storybook and Vitest.