### PR TITLE
Update remark-modified-time.mjs to use git's AuthorDate

### DIFF
--- a/scripts/remark-modified-time.mjs
+++ b/scripts/remark-modified-time.mjs
@@ -3,7 +3,7 @@ import { execSync } from "node:child_process";
 export function remarkModifiedTime() {
   return (_tree, file) => {
     const filepath = file.history[0];
-    const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
+    const result = execSync(`git log -1 --pretty="format:%aI" "${filepath}"`);
     file.data.astro.frontmatter.lastModified = result.toString();
   };
 }


### PR DESCRIPTION
Changes the remark-modified-time plugin to use git's AuthorDate (`%aI`) instead of the CommitterDate (`%cI`). AuthorDate should more accurately reflect the true "last modified" time as it represents the time something is first committed. CommitterDate represents the time of the last git action involving that file (rebase, etc). 

This is a very small change discussed in the broader https://github.com/namesakefyi/namesake/issues/623 issue ticket. 