### PR TITLE
fix: Do not prerender redirect pages

### DIFF
--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -1,5 +1,4 @@
 ---
-
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 

--- a/web/src/pages/chat.astro
+++ b/web/src/pages/chat.astro
@@ -1,3 +1,5 @@
 ---
+export const prerender = false;
+
 return Astro.redirect("https://discord.gg/8Vy2bbQ5C2", 308);
 ---

--- a/web/src/pages/donate.astro
+++ b/web/src/pages/donate.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 // We have to import siteInfo as _siteInfo to avoid an Astro type bug
 // See https://github.com/withastro/astro/issues/14684
 import { siteInfo as _siteInfo } from "#constants/site-info";

--- a/web/src/pages/status.astro
+++ b/web/src/pages/status.astro
@@ -1,3 +1,5 @@
 ---
+export const prerender = false;
+
 return Astro.redirect("https://status.namesake.fyi", 308);
 ---


### PR DESCRIPTION
Attempting to static render pages which contain redirects shows an undesirable intermediate page and throws errors about missing `<html>` tags when using pagefind.

Update all pages that have redirects to disable prerendering.