### PR TITLE
Display map embeds alongside addresses

### DIFF
--- a/web/src/components/MapEmbed.astro
+++ b/web/src/components/MapEmbed.astro
@@ -14,7 +14,6 @@ const { name, address } = Astro.props;
 
 const url = new URL("https://maps.google.com/maps");
 url.searchParams.set("q", name);
-url.searchParams.set("t", "m"); // Map type: 'm'=map, 'k'=satellite, 'h'=hybrid, 'p'=terrain
 url.searchParams.set("output", "embed");
 ---
 

--- a/web/src/components/MapEmbed.astro
+++ b/web/src/components/MapEmbed.astro
@@ -1,0 +1,64 @@
+---
+interface Props {
+  name: string;
+  address: {
+    address1: string;
+    address2?: string;
+    city: string;
+    state: string;
+    zip: string;
+  };
+}
+
+const { name, address } = Astro.props;
+
+const url = new URL("https://maps.google.com/maps");
+url.searchParams.set("q", name);
+url.searchParams.set("t", "m"); // Map type: 'm'=map, 'k'=satellite, 'h'=hybrid, 'p'=terrain
+url.searchParams.set("output", "embed");
+---
+
+<figure class="map-embed">
+  <div class="map">
+    <iframe
+      src={url.toString()}
+      width="800"
+      height="450"
+      allowfullscreen=""
+      loading="lazy"
+      referrerpolicy="no-referrer-when-downgrade"></iframe>
+  </div>
+  <figcaption class="map-address">
+    <strong>{name}</strong><br />
+    {address.address1}
+    {address.address2}<br />
+    {address.city}, {address.state}
+    {address.zip}
+  </figcaption>
+</figure>
+
+<style>
+  .map-embed {
+    border: 1px solid var(--border-color);
+  }
+
+  .map-address {
+    padding: var(--space-m);
+  }
+
+  .map {
+    overflow: hidden;
+    padding-bottom: 56.25%;
+    position: relative;
+    height: 0;
+
+    iframe {
+      position: absolute;
+      border: 0;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+</style>

--- a/web/src/content/guides/passport.mdx
+++ b/web/src/content/guides/passport.mdx
@@ -14,7 +14,7 @@ For more information, the ACLU has published a [Q&A guide about Orr v. Trump](ht
 
 ## Get prepared
 
-To change your name on your passport, you will need a completed **court order **and a new **social security** **card** reflecting your new name.
+To change your name on your passport, you will need a **completed court order** and a new **[social security card](/guides/social-security)** reflecting your new name.
 
 ## Fill out forms
 

--- a/web/src/content/guides/ri/birth-certificate.mdx
+++ b/web/src/content/guides/ri/birth-certificate.mdx
@@ -6,8 +6,9 @@ category: birth-certificate
 ---
 
 import Costs from "../../../components/Costs.astro"
+import MapEmbed from "../../../components/MapEmbed.astro"
 
-In Rhode Island, changes to birth certificates are handled by the Rhode Island Department of Health's [Office of Vital Records](https://health.ri.gov/vital-records).
+In Rhode Island, changes to birth certificates are handled by the Rhode Island Department of Health's [Center for Vital Records](https://health.ri.gov/vital-records).
 
 You can update your **name** and/or **gender marker** on your Rhode Island birth certificate. Rhode Island allows **M**, **F**, and **X** gender markers on birth certificates. No medical documentation is required.
 
@@ -48,19 +49,15 @@ To submit in person, gather:
   {"title":"Additional copies (each)","amount":18,"required":"notRequired"}
 ]} />
 
-Bring all documents to the Office of Vital Records:
+Bring all documents to the Center for Vital Records:
 
-[**Rhode Island Department of Health  
-Office of Vital Records**](https://maps.app.goo.gl/ZoqpN1oj7TLSLZY76)  
-Simpson Hall  
-6 Harrington Road  
-Cranston, Rhode Island 02920
+<MapEmbed name="Rhode Island Department of Health Center for Vital Records" address={{ address1: "Simpson Hall", address2: "6 Harrington Road", city: "Cranston", state: "Rhode Island", zip: "02920" }} />
 
-You will not receive your amended birth certificate the same day as you appear at the Office of Vital Records. It will be mailed to you after your application has been processed.
+You will not receive your amended birth certificate the same day as you appear at the Center for Vital Records. It will be mailed to you after your application has been processed.
 
-You can save time at the Office of Vital Records by calling [(401) 222-5339](tel:401-222-5339) to schedule an appointment to submit your application.
+You can save time at the Center for Vital Records by calling [(401) 222-5339](tel:401-222-5339) to schedule an appointment to submit your application.
 
-If you are also updating your gender marker, The Office of Vital Records will prepare an affidavit to sign while you are there.
+If you are also updating your gender marker, The Center for Vital Records will prepare an affidavit to sign while you are there.
 
 ### Submit by mail
 
@@ -77,9 +74,9 @@ To submit your application by mail, gather:
   {"title":"Additional copies (each)","amount":18,"required":"notRequired"}
 ]} />
 
-**If you are updating your gender marker, you will need to contact the Office of Vital Records to request an affidavit before mailing your application:**
+**If you are updating your gender marker, you will need to contact the Center for Vital Records to request an affidavit before mailing your application:**
 
-1. Call the Office of Vital Records at [(401) 222-5339](tel:401-222-5339).
+1. Call the Center for Vital Records at [(401) 222-5339](tel:401-222-5339).
 2. Inform the office that you are seeking to change the gender marker on your Rhode Island birth certificate and that you need an affidavit.
    - Tell them the gender marker currently on your birth certificate and the gender you would like to update it to.
    - Give them your biographical information including your name at birth, date of birth, place of birth, and current legal name (if you changed it with the court).
@@ -89,7 +86,7 @@ To submit your application by mail, gather:
 Mail all documents to:
 
 [**Rhode Island Department of Health  
-Office of Vital Records**](https://maps.app.goo.gl/ZoqpN1oj7TLSLZY76)  
+Center for Vital Records**](https://maps.app.goo.gl/ZoqpN1oj7TLSLZY76)  
 Simpson Hall  
 6 Harrington Road  
 Cranston, Rhode Island 02920

--- a/web/src/content/guides/ri/court-order.mdx
+++ b/web/src/content/guides/ri/court-order.mdx
@@ -6,6 +6,7 @@ category: court-order
 ---
 
 import { FormContainer } from "../../../components/forms/FormContainer"
+import MapEmbed from "../../../components/MapEmbed.astro"
 
 ## Get prepared
 
@@ -128,10 +129,7 @@ To get a background check in person, you will need to travel to Cranston. Collec
 
 Bring your documents to:
 
-**Rhode Island Attorney General  
-Customer Service Center**  
-[4 Howard Avenue  
-Cranston, RI 02920](https://maps.app.goo.gl/YG6D9ko4THR6QWUb6)
+<MapEmbed name="Rhode Island Attorney General Customer Service Center" address={{ address1: "4 Howard Ave", city: "Cranston", state: "RI", zip: "02920" }} />
 
 Hours of operation are:
 

--- a/web/src/layouts/ProseLayout.astro
+++ b/web/src/layouts/ProseLayout.astro
@@ -245,30 +245,18 @@ const headerDescription =
     }
 
     details:not(:where(.not-content *)) {
-      --details-transition-duration: 0.2s;
-
       padding-inline-start: var(--space-2xl);
-      transition-property: margin-block-start;
-      transition-duration: var(--details-transition-duration);
-      transition-timing-function: ease;
 
-      @media (prefers-reduced-motion: no-preference) {
-        interpolate-size: allow-keywords;
-      }
-
-      &::details-content {
-        block-size: 0;
-        opacity: 0;
-        overflow-y: clip;
-        transition-property: content-visibility, block-size, opacity;
-        transition-duration: var(--details-transition-duration);
-        transition-timing-function: ease;
-        transition-behavior: allow-discrete;
-      }
-
-      &[open]::details-content {
-        block-size: auto;
-        opacity: 1;
+      summary::before {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M18 12L9 17.196L9 6.804Z'%3E%3C/path%3E%3C/svg%3E");
+        scale: 0.9;
+        rotate: 0deg;
+        transition: rotate 0.3s ease-in-out;
+        position: absolute;
+        left: calc(var(--space-2xl) * -1);
+        top: -0.05em;
+        width: 1lh;
+        height: 1lh;
       }
 
       &[open] summary::before {
@@ -291,20 +279,6 @@ const headerDescription =
       &:-webkit-details-marker,
       &::marker {
         display: none;
-      }
-
-      &::before {
-        content: "";
-        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M13.1717 12.0007L8.22192 7.05093L9.63614 5.63672L16.0001 12.0007L9.63614 18.3646L8.22192 16.9504L13.1717 12.0007Z'%3E%3C/path%3E%3C/svg%3E");
-        background-repeat: no-repeat;
-        background-position: center;
-        background-size: 75%;
-        transition: rotate 0.15s ease-out;
-        position: absolute;
-        left: calc(var(--space-2xl) * -1);
-        top: -0.05em;
-        width: 1lh;
-        height: 1lh;
       }
     }
   }


### PR DESCRIPTION
Add a new `MapEmbed` Astro component to display a responsive Google Map iframe within the contents of a guide.

<img width="1442" height="1172" alt="CleanShot 2026-06-19 at 16 22 08@2x" src="https://github.com/user-attachments/assets/1da2fd27-751a-49f4-adbd-7ad7120a621a" />

Tweak the display of `details` elements to remove the animation from expand/collapse of the text and modify the triangle/chevron.