### PR TITLE
feat: add custom OpenGraph image for /directory

### DIFF
--- a/web/src/pages/directory.png.ts
+++ b/web/src/pages/directory.png.ts
@@ -1,0 +1,11 @@
+import type { APIRoute } from "astro";
+import { createOgImageResponse } from "#lib/utils/createOgImageResponse";
+
+export const GET: APIRoute = async ({ request }) => {
+  return await createOgImageResponse({
+    subhead: "Need more name change support? These organizations can help.",
+    title: "Directory",
+    color: "pink",
+    origin: new URL(request.url).origin,
+  });
+};

--- a/web/src/pages/directory/index.astro
+++ b/web/src/pages/directory/index.astro
@@ -57,7 +57,12 @@ const description =
   "Need more name change support? These organizations can help.";
 ---
 
-<BaseLayout title={title} description={description} color="pink">
+<BaseLayout
+  title={title}
+  description={description}
+  color="pink"
+  ogImage="/directory.png"
+>
   <PageHeader title={title} description={description} />
   <section class="directory-filters" aria-label="Directory filters">
     <form id="directory-form" method="get" class="controls">


### PR DESCRIPTION
Closes #430.

## What

`/directory` was the only main content landing page falling back to the default site OG image (`/og/social.png`). The blog, forms, and guides sections each generate a per-page OG image; this brings the directory in line.

## How

- New `web/src/pages/directory.png.ts` — a static `/directory.png` route that calls the existing `createOgImageResponse` helper (title **"Directory"**, the page's own description as the subhead, `color: "pink"` to match the page's theme color).
- Wires it into `web/src/pages/directory/index.astro` via `BaseLayout`'s existing `ogImage` prop.

No new dependencies; reuses the same `cf-workers-og` pipeline and `OgImage` component as the other sections.

## Preview

The generated 1200×630 image:

- Pink background (matches `color="pink"` on the page)
- Subhead: *"Need more name change support? These organizations can help."*
- Title: **Directory**
- Namesake wordmark + speckle texture, identical to the blog/forms/guides OG images

## Notes

The issue also mentions hooking up Sanity for per-page OG images. That's a larger, separate effort (no Sanity integration exists in the repo today), so this PR scopes to the titled ask — giving `/directory` a custom OG image using the established pattern. Happy to follow up on the CMS-driven approach if you'd like it tracked separately.

## Verification

- `biome check` — clean
- `astro check` — 0 errors / 0 warnings / 0 hints
- `astro build` — `/directory.png` emitted as a valid 1200×630 PNG; built `/directory` page's `og:image` meta resolves to `https://namesake.fyi/directory.png`
