### PR TITLE
feat: add OpenGraph images for the blog, forms, and guides index pages

### DIFF
--- a/web/src/pages/blog.png.ts
+++ b/web/src/pages/blog.png.ts
@@ -1,0 +1,11 @@
+import type { APIRoute } from "astro";
+import { createOgImageResponse } from "#lib/utils/createOgImageResponse";
+
+export const GET: APIRoute = async ({ request }) => {
+  return await createOgImageResponse({
+    subhead: "The latest news from Namesake.",
+    title: "Blog",
+    color: "blue",
+    origin: new URL(request.url).origin,
+  });
+};

--- a/web/src/pages/blog/index.astro
+++ b/web/src/pages/blog/index.astro
@@ -22,6 +22,7 @@ const posts = allPosts
   title="Blog"
   description="The latest news from Namesake."
   color="blue"
+  ogImage="/blog.png"
 >
   <PageHeader title="Blog" description="The latest news from Namesake." />
   <div class="posts">

--- a/web/src/pages/forms.png.ts
+++ b/web/src/pages/forms.png.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro";
+import { createOgImageResponse } from "#lib/utils/createOgImageResponse";
+
+export const GET: APIRoute = async ({ request }) => {
+  return await createOgImageResponse({
+    subhead:
+      "Namesake's guided forms can help you fill out all the name change documents you need to file.",
+    title: "Forms",
+    color: "white",
+    origin: new URL(request.url).origin,
+  });
+};

--- a/web/src/pages/forms/index.astro
+++ b/web/src/pages/forms/index.astro
@@ -31,6 +31,7 @@ const formsWithPdfs = await Promise.all(
   title="Forms"
   description="Namesake's guided forms can help you fill out all the name change documents you need to file."
   color="white"
+  ogImage="/forms.png"
 >
   <PageHeader
     title="Forms"

--- a/web/src/pages/guides.png.ts
+++ b/web/src/pages/guides.png.ts
@@ -1,0 +1,11 @@
+import type { APIRoute } from "astro";
+import { createOgImageResponse } from "#lib/utils/createOgImageResponse";
+
+export const GET: APIRoute = async ({ request }) => {
+  return await createOgImageResponse({
+    subhead: "Step-by-step name change guides for identity documents.",
+    title: "Guides",
+    color: "white",
+    origin: new URL(request.url).origin,
+  });
+};

--- a/web/src/pages/guides/index.astro
+++ b/web/src/pages/guides/index.astro
@@ -11,6 +11,7 @@ const { generalGuides, guidesByState } = await getGuidesByState();
   title="Guides"
   description="Step-by-step name change guides for identity documents."
   color="white"
+  ogImage="/guides.png"
 >
   <PageHeader
     title="Guides"


### PR DESCRIPTION
Closes #649.

## What

The blog, forms, and guides **section index** pages (`/blog`, `/forms`, `/guides`) were falling back to the default site OG image (`/og/social.png`), even though their detail pages each generate a custom one — and #430 / #648 just added one for `/directory`. This brings the three index pages in line.

## How

Three static OG routes, each calling the existing `createOgImageResponse` helper:

- `web/src/pages/blog.png.ts` → title **Blog**, color `blue`
- `web/src/pages/forms.png.ts` → title **Forms**, color `white`
- `web/src/pages/guides.png.ts` → title **Guides**, color `white`

Each uses the page's own existing `description` as the subhead and the section's existing `color`, then wires the image in via `BaseLayout`'s `ogImage` prop. No new dependencies; same `cf-workers-og` pipeline and `OgImage` component as everywhere else.

## Notes

The forms description is long enough to wrap to two lines in the image; `OgImage` handles this cleanly (text wraps at the content width, no clipping).

## Verification

- `biome check` — clean
- `astro build` — `/blog.png`, `/forms.png`, `/guides.png` all emitted as valid 1200×630 PNGs; each built index page's `og:image` meta resolves to the matching `https://namesake.fyi/<section>.png`
- Visually inspected all three renders against the existing blog/forms/guides/directory OG images for consistency
