### PR TITLE
Improve performance: remove every.org inline script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ stats.html
 
 # sanity generated schema
 schema.json
+
+# lighthouse
+.unlighthouse

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -78,8 +78,6 @@ const pageTitle = Astro.url.pathname === "/" ? title : `${title} · Namesake`;
       title="Namesake"
       href={new URL("rss.xml", Astro.site)}
     />
-    <script is:inline async defer src="https://embeds.every.org/0.4/button.js"
-    ></script>
   </head>
   <body data-color={color}>
     <Header />
@@ -89,9 +87,9 @@ const pageTitle = Astro.url.pathname === "/" ? title : `${title} · Namesake`;
     <Footer />
     <script>
       // Print media lazy-loading bypass
-      window.addEventListener('beforeprint', () => {
-        document.querySelectorAll('img[loading]').forEach(img => {
-          img.removeAttribute('loading');
+      window.addEventListener("beforeprint", () => {
+        document.querySelectorAll("img[loading]").forEach((img) => {
+          img.removeAttribute("loading");
         });
       });
     </script>


### PR DESCRIPTION
Remove the inline `embeds.every.org` script to improve performance.

Link directly to the donation page when the URL is clicked.