### PR TITLE
fix(pdf-manager): detect PDFRadioGroup fields instead of classifying as text

### DIFF
--- a/pdf-manager/lib/pdf.ts
+++ b/pdf-manager/lib/pdf.ts
@@ -59,7 +59,23 @@ export function fieldReadingOrder(
 
 export interface PdfFieldInfo {
   name: string;
-  type: "text" | "checkbox";
+  type: "text" | "checkbox" | "radio";
+}
+
+/**
+ * Maps a pdf-lib form field to the simplified type used by the PDF Manager UI.
+ * Radio groups and checkboxes are detected explicitly; everything else (text
+ * fields and any field class we don't render specially) falls back to "text".
+ */
+function fieldType(field: PDFField): PdfFieldInfo["type"] {
+  switch (field.constructor.name) {
+    case "PDFCheckBox":
+      return "checkbox";
+    case "PDFRadioGroup":
+      return "radio";
+    default:
+      return "text";
+  }
 }
 
 export async function extractFields(pdfPath: string): Promise<PdfFieldInfo[]> {
@@ -75,7 +91,7 @@ export async function extractFieldsFromBytes(
   const sorted = fieldReadingOrder(form.getFields(), doc.getPages());
   return sorted.map((f) => ({
     name: f.getName(),
-    type: f.constructor.name === "PDFCheckBox" ? "checkbox" : "text",
+    type: fieldType(f),
   }));
 }
 

--- a/pdf-manager/src/components/FieldList.tsx
+++ b/pdf-manager/src/components/FieldList.tsx
@@ -68,6 +68,23 @@ function FieldTypeIcon({ type }: { type: Field["type"] }) {
       </svg>
     );
   }
+  if (type === "radio") {
+    return (
+      <svg
+        className="field-type-icon"
+        viewBox="0 0 12 12"
+        width="12"
+        height="12"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        aria-hidden="true"
+      >
+        <circle cx="6" cy="6" r="4.5" />
+        <circle cx="6" cy="6" r="1.8" fill="currentColor" stroke="none" />
+      </svg>
+    );
+  }
   return (
     <svg
       className="field-type-icon"

--- a/pdf-manager/src/types.ts
+++ b/pdf-manager/src/types.ts
@@ -1,6 +1,6 @@
 export interface Field {
   name: string;
-  type: "text" | "checkbox";
+  type: "text" | "checkbox" | "radio";
   excluded?: boolean;
 }
 


### PR DESCRIPTION
## Summary

The PDF Manager at `/pdf-manager` was classifying `PDFRadioGroup` fields as `text`. The detection in `extractFieldsFromBytes` only special-cased `PDFCheckBox` and treated everything else as `text`, so radio groups got the wrong type and were shown with the text icon (noticed in #656, the first uploaded form that contains radio groups).

## Changes

- `pdf-manager/lib/pdf.ts` – add a small `fieldType()` helper that maps `PDFCheckBox` → `checkbox`, `PDFRadioGroup` → `radio`, and everything else → `text`, and add `"radio"` to `PdfFieldInfo["type"]`.
- `pdf-manager/src/types.ts` – add `"radio"` to `Field["type"]`.
- `pdf-manager/src/components/FieldList.tsx` – render a radio icon for `radio` fields.

The schema generation in `lib/schema.ts` already records the raw `constructor.name`, so generated schemas keep flagging these fields as `PDFRadioGroup`.

## Testing

Built an in-memory PDF with a text field, a checkbox and a radio group, then ran `extractFieldsFromBytes` on it.

Before:

```
full_name    -> text
agree_terms  -> checkbox
sex_marker   -> text       (radio group — wrong)
```

After:

```
full_name    -> text
agree_terms  -> checkbox
sex_marker   -> radio
```

`tsc --noEmit` and `biome check` both pass.

Closes #659
