### PR TITLE
Modify coverage workflow organization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,27 +52,3 @@ jobs:
 
       - name: Biome
         run: pnpm biome ci
-
-  test:
-    name: Unit Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v6.0.9
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24.x"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run tests
-        run: pnpm --filter @namesake/web test

--- a/.github/workflows/coverage-branch.yml
+++ b/.github/workflows/coverage-branch.yml
@@ -8,13 +8,6 @@ on:
       - ".vscode/**"
       - "docs/**"
       - "pdf-manager/**"
-  push:
-    branches: [main]
-    paths-ignore:
-      - ".changeset/**"
-      - ".vscode/**"
-      - "docs/**"
-      - "pdf-manager/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,9 +17,8 @@ permissions:
   contents: read
 
 jobs:
-  # Runs on PRs: test coverage for the branch under review.
+  # Test coverage for the branch under review.
   test-coverage-branch:
-    if: github.event_name == 'pull_request'
     name: Test Coverage (branch)
     runs-on: ubuntu-latest
 
@@ -60,44 +52,7 @@ jobs:
           path: web/coverage
           overwrite: true
 
-  # Runs on pushes to main: refresh the cached baseline coverage that PRs
-  # compare against, so PRs don't each have to re-run main's test suite.
-  test-coverage-main:
-    if: github.event_name == 'push'
-    name: Test Coverage (main)
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.9
-        with:
-          run_install: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24.x"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Test coverage
-        run: pnpm --filter @namesake/web test:coverage
-
-      - name: Cache coverage
-        uses: actions/cache/save@v5.0.5
-        with:
-          path: web/coverage
-          key: coverage-main-${{ github.sha }}
-
   report-coverage:
-    if: github.event_name == 'pull_request'
     needs: [test-coverage-branch]
     name: Report Coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage-branch.yml
+++ b/.github/workflows/coverage-branch.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   # Test coverage for the branch under review.
   test-coverage-branch:
-    name: Test Coverage (branch)
+    name: Test Coverage
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,53 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - ".changeset/**"
+      - ".vscode/**"
+      - "docs/**"
+      - "pdf-manager/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Refreshes the cached baseline coverage that PRs compare against, so PRs
+  # don't each have to re-run main's test suite.
+  cache-coverage-main:
+    name: Cache Coverage (main)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.9
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.x"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache coverage
+        run: pnpm --filter @namesake/web test:coverage
+
+      - name: Save coverage cache
+        uses: actions/cache/save@v5.0.5
+        with:
+          path: web/coverage
+          key: coverage-main-${{ github.sha }}

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -20,7 +20,7 @@ jobs:
   # Refreshes the cached baseline coverage that PRs compare against, so PRs
   # don't each have to re-run main's test suite.
   cache-coverage-main:
-    name: Cache Coverage (main)
+    name: Cache Coverage
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Followup to #669 to prevent irrelevant "skipped" workflows from showing up in the test UI on main/branches.

Remove the unit test from CI altogether, since it's the same test logic as runs for the coverage check.