### PR TITLE
Do not prerender directory page

### DIFF
--- a/web/src/pages/directory/index.astro
+++ b/web/src/pages/directory/index.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
 import {


### PR DESCRIPTION
Filters on the `/directory` page were not working due to static rendering introduced in #641.

Server-render the directory to properly allow filtering via search params in the URL.