### PR TITLE
Add individual directory pages and related links

### DIFF
--- a/web/src/components/DirectoryLogo.astro
+++ b/web/src/components/DirectoryLogo.astro
@@ -13,17 +13,12 @@ const { logo, name, class: className, ...rest } = Astro.props;
 
 {
   logo.format === "svg" ? (
-    <img
-      class:list={["logo", className]}
-      src={logo.src}
-      alt={`${name} logo`}
-      {...rest}
-    />
+    <img class:list={["logo", className]} src={logo.src} alt="" {...rest} />
   ) : (
     <Image
       class:list={["logo", className]}
       src={logo}
-      alt={`${name} logo`}
+      alt=""
       width={300}
       densities={[1, 2]}
       {...rest}
@@ -33,7 +28,7 @@ const { logo, name, class: className, ...rest } = Astro.props;
 
 <style>
   .logo {
-    width: 100%;
+    width: auto;
     max-width: fit-content;
     mix-blend-mode: multiply;
     filter: grayscale(100%);

--- a/web/src/components/DirectoryLogo.astro
+++ b/web/src/components/DirectoryLogo.astro
@@ -1,0 +1,41 @@
+---
+import { Image } from "astro:assets";
+import type { ImageMetadata } from "astro";
+
+interface Props {
+  logo: ImageMetadata;
+  name: string;
+  class?: string;
+}
+
+const { logo, name, class: className, ...rest } = Astro.props;
+---
+
+{
+  logo.format === "svg" ? (
+    <img
+      class:list={["logo", className]}
+      src={logo.src}
+      alt={`${name} logo`}
+      {...rest}
+    />
+  ) : (
+    <Image
+      class:list={["logo", className]}
+      src={logo}
+      alt={`${name} logo`}
+      width={300}
+      densities={[1, 2]}
+      {...rest}
+    />
+  )
+}
+
+<style>
+  .logo {
+    width: 100%;
+    max-width: fit-content;
+    mix-blend-mode: multiply;
+    filter: grayscale(100%);
+  }
+</style>

--- a/web/src/components/InlineLinkList.astro
+++ b/web/src/components/InlineLinkList.astro
@@ -1,0 +1,43 @@
+---
+interface Item {
+  name: string;
+  href: string;
+}
+
+interface Props {
+  items: Item[];
+  underlineStyle?: "constant" | "hover";
+}
+
+const { items, underlineStyle = "constant" } = Astro.props;
+---
+
+{
+  items.map((item, i) => (
+    <>
+      <a href={item.href} data-underline={underlineStyle}>
+        {item.name}
+      </a>
+      {i < items.length - 1 ? ", " : ""}
+    </>
+  ))
+}
+
+<style>
+  a {
+    color: var(--text-color);
+    text-decoration: none;
+
+    &[data-underline="constant"] {
+      text-decoration: underline;
+    }
+
+    &[data-underline="hover"] {
+      @media (hover: hover) {
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+</style>

--- a/web/src/components/PageHeader.astro
+++ b/web/src/components/PageHeader.astro
@@ -41,6 +41,7 @@ if (date) {
       </time>
     )
   }
+  <slot name="before-header" />
   <h1
     data-annotation={annotation}
     data-pagefind-meta={`title:${searchTitle ?? title}`}

--- a/web/src/components/RelatedDirectoryEntries.astro
+++ b/web/src/components/RelatedDirectoryEntries.astro
@@ -11,17 +11,17 @@ export interface RelatedEntry {
 interface Props {
   entries: RelatedEntry[];
   stateId: string;
-  stateName: string;
+  heading: string;
 }
 
-const { entries, stateId, stateName } = Astro.props;
+const { entries, stateId, heading } = Astro.props;
 ---
 
 {
   entries.length > 0 && (
     <aside class="related">
       <h2>
-        Also in <a href={`/directory?state=${stateId}`}>{stateName}</a>
+        <a href={`/directory?state=${stateId}`}>{heading}</a>
       </h2>
       <ul>
         {entries.map((entry) => (

--- a/web/src/components/RelatedDirectoryEntries.astro
+++ b/web/src/components/RelatedDirectoryEntries.astro
@@ -1,6 +1,5 @@
 ---
 import type { ImageMetadata } from "astro";
-import DirectoryLogo from "./DirectoryLogo.astro";
 
 export interface RelatedEntry {
   id: string;
@@ -86,15 +85,12 @@ const { entries, stateId, stateName } = Astro.props;
         font-weight: var(--weight-bold);
         color: var(--text-color);
         text-decoration: none;
+        outline-color: transparent;
 
         &::after {
           content: "";
           position: absolute;
           inset: 0;
-        }
-
-        &:focus {
-          outline: none;
         }
 
         &:focus-visible::after {

--- a/web/src/components/RelatedDirectoryEntries.astro
+++ b/web/src/components/RelatedDirectoryEntries.astro
@@ -19,7 +19,7 @@ const { entries, stateId, heading } = Astro.props;
 
 {
   entries.length > 0 && (
-    <aside class="related">
+    <aside class="related" data-pagefind-ignore>
       <h2>
         <a href={`/directory?state=${stateId}`}>{heading}</a>
       </h2>

--- a/web/src/components/RelatedDirectoryEntries.astro
+++ b/web/src/components/RelatedDirectoryEntries.astro
@@ -1,0 +1,111 @@
+---
+import type { ImageMetadata } from "astro";
+import DirectoryLogo from "./DirectoryLogo.astro";
+
+export interface RelatedEntry {
+  id: string;
+  name: string;
+  description: string;
+  logo?: ImageMetadata;
+}
+
+interface Props {
+  entries: RelatedEntry[];
+  stateId: string;
+  stateName: string;
+}
+
+const { entries, stateId, stateName } = Astro.props;
+---
+
+{
+  entries.length > 0 && (
+    <aside class="related">
+      <h2>
+        Also in <a href={`/directory?state=${stateId}`}>{stateName}</a>
+      </h2>
+      <ul>
+        {entries.map((entry) => (
+          <li>
+            <a class="name" href={`/directory/${entry.id}`}>
+              {entry.name}
+            </a>
+            <p>{entry.description}</p>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  )
+}
+
+<style>
+  .related {
+    padding-block-end: var(--space-xl);
+  }
+
+  h2 {
+    font-size: var(--step-1);
+    font-weight: var(--weight-bold);
+    margin-block-end: var(--space-l);
+
+    a {
+      color: inherit;
+      text-decoration: none;
+
+      @media (hover: hover) {
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+
+  ul {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: var(--space-l);
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    li {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2xs);
+      padding: var(--space-m);
+      border: 1px solid var(--border-color);
+
+      @media (hover: hover) {
+        &:hover a {
+          text-decoration: underline;
+        }
+      }
+
+      a {
+        font-weight: var(--weight-bold);
+        color: var(--text-color);
+        text-decoration: none;
+
+        &::after {
+          content: "";
+          position: absolute;
+          inset: 0;
+        }
+
+        &:focus {
+          outline: none;
+        }
+
+        &:focus-visible::after {
+          outline: 3px solid var(--focus-ring-color);
+        }
+      }
+
+      p {
+        margin: 0;
+        font-size: var(--step--1);
+      }
+    }
+  }
+</style>

--- a/web/src/pages/directory/[slug].astro
+++ b/web/src/pages/directory/[slug].astro
@@ -1,0 +1,186 @@
+---
+import { type CollectionEntry, getCollection } from "astro:content";
+import DirectoryLogo from "#components/DirectoryLogo.astro";
+import PageHeader from "#components/PageHeader.astro";
+import RelatedDirectoryEntries, {
+  type RelatedEntry,
+} from "#components/RelatedDirectoryEntries.astro";
+import { SERVICE_LABELS, type Service } from "#constants/services";
+import BaseLayout from "#layouts/BaseLayout.astro";
+import { formatCleanUrl } from "#lib/utils/formatCleanUrl";
+
+export async function getStaticPaths() {
+  const [entries, jurisdictions] = await Promise.all([
+    getCollection("directory"),
+    getCollection("jurisdictions"),
+  ]);
+  return entries.map((entry) => {
+    const entryJurisdictions = entry.data.jurisdictions
+      .map((ref) => ({
+        id: ref.id,
+        name: jurisdictions.find((j) => j.id === ref.id)?.data.name ?? ref.id,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    const firstJurisdiction = entryJurisdictions[0];
+    const relatedEntries: RelatedEntry[] = firstJurisdiction
+      ? entries
+          .filter(
+            (e) =>
+              e.id !== entry.id &&
+              e.data.jurisdictions.some(
+                (ref) => ref.id === firstJurisdiction.id,
+              ),
+          )
+          .sort((a, b) => {
+            if (a.data.officialPartner !== b.data.officialPartner)
+              return a.data.officialPartner ? -1 : 1;
+            return a.data.name.localeCompare(b.data.name);
+          })
+          .slice(0, 3)
+          .map((e) => ({
+            id: e.id,
+            name: e.data.name,
+            description: e.data.description,
+            logo: e.data.logo,
+          }))
+      : [];
+
+    return {
+      params: { slug: entry.id },
+      props: { entry, entryJurisdictions, relatedEntries, firstJurisdiction },
+    };
+  });
+}
+
+interface Props {
+  entry: CollectionEntry<"directory">;
+  entryJurisdictions: { id: string; name: string }[];
+  relatedEntries: RelatedEntry[];
+  firstJurisdiction: { id: string; name: string } | undefined;
+}
+
+const { entry, entryJurisdictions, relatedEntries, firstJurisdiction } =
+  Astro.props;
+const { name, description, services, email, phone, url, logo } = entry.data;
+---
+
+<BaseLayout title={name} description={description} color="pink">
+  <PageHeader
+    title={name}
+    description={description}
+    annotation="underline"
+    breadcrumbs={[{ label: "Directory", href: "/directory" }]}
+  >
+    {
+      logo && (
+        <DirectoryLogo
+          slot="before-header"
+          class="entry-logo"
+          logo={logo}
+          name={name}
+        />
+      )
+    }
+  </PageHeader>
+  <section class="entry-layout">
+    <dl class="entry-meta">
+      <dt>Services</dt>
+      <dd>
+        {
+          services.map((svc, i) => (
+            <>
+              <a href={`/directory?service=${svc}`}>
+                {SERVICE_LABELS[svc as Service] ?? svc}
+              </a>
+              {i < services.length - 1 ? ", " : ""}
+            </>
+          ))
+        }
+      </dd>
+      <dt>{entryJurisdictions.length > 1 ? "States" : "State"}</dt>
+      <dd>
+        {
+          entryJurisdictions.map((j, i) => (
+            <>
+              <a href={`/directory?state=${j.id}`}>{j.name}</a>
+              {i < entryJurisdictions.length - 1 ? ", " : ""}
+            </>
+          ))
+        }
+      </dd>
+      {
+        url && (
+          <>
+            <dt>Website</dt>
+            <dd>
+              <a href={url}>{formatCleanUrl(url)}</a>
+            </dd>
+          </>
+        )
+      }
+      {
+        email && (
+          <>
+            <dt>Email</dt>
+            <dd>
+              <a href={`mailto:${email}`}>{email}</a>
+            </dd>
+          </>
+        )
+      }
+      {
+        phone && (
+          <>
+            <dt>Phone</dt>
+            <dd>
+              <a href={`tel:${phone}`}>{phone}</a>
+            </dd>
+          </>
+        )
+      }
+    </dl>
+  </section>
+  {firstJurisdiction && (
+    <RelatedDirectoryEntries
+      entries={relatedEntries}
+      stateId={firstJurisdiction.id}
+      stateName={firstJurisdiction.name}
+    />
+  )}
+</BaseLayout>
+
+<style>
+  .entry-logo {
+    max-height: 140px;
+    margin-block-end: var(--space-m);
+  }
+
+  .entry-layout {
+    margin-block-end: var(--space-xl);
+  }
+
+  .entry-meta {
+    margin: 0;
+
+    dt {
+      font-weight: var(--weight-bold);
+    }
+
+    dd {
+      margin: 0;
+      margin-block-end: var(--space-s);
+    }
+
+    a {
+      color: var(--text-color);
+      text-decoration: none;
+
+      @media (hover: hover) {
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+</style>

--- a/web/src/pages/directory/[slug].astro
+++ b/web/src/pages/directory/[slug].astro
@@ -1,6 +1,7 @@
 ---
-import { type CollectionEntry, getCollection } from "astro:content";
+import { getCollection } from "astro:content";
 import DirectoryLogo from "#components/DirectoryLogo.astro";
+import InlineLinkList from "#components/InlineLinkList.astro";
 import PageHeader from "#components/PageHeader.astro";
 import RelatedDirectoryEntries, {
   type RelatedEntry,
@@ -22,14 +23,13 @@ export async function getStaticPaths() {
       }))
       .sort((a, b) => a.name.localeCompare(b.name));
 
-    const firstJurisdiction = entryJurisdictions[0];
-    const relatedEntries: RelatedEntry[] = firstJurisdiction
+    const relatedEntries: RelatedEntry[] = entryJurisdictions[0]
       ? entries
           .filter(
-            (e) =>
-              e.id !== entry.id &&
-              e.data.jurisdictions.some(
-                (ref) => ref.id === firstJurisdiction.id,
+            (relatedEntry) =>
+              relatedEntry.id !== entry.id &&
+              relatedEntry.data.jurisdictions.some(
+                (ref) => ref.id === entryJurisdictions[0].id,
               ),
           )
           .sort((a, b) => {
@@ -38,30 +38,23 @@ export async function getStaticPaths() {
             return a.data.name.localeCompare(b.data.name);
           })
           .slice(0, 3)
-          .map((e) => ({
-            id: e.id,
-            name: e.data.name,
-            description: e.data.description,
-            logo: e.data.logo,
+          .map((relatedEntry) => ({
+            id: relatedEntry.id,
+            name: relatedEntry.data.name,
+            description: relatedEntry.data.description,
+            logo: relatedEntry.data.logo,
           }))
       : [];
 
     return {
       params: { slug: entry.id },
-      props: { entry, entryJurisdictions, relatedEntries, firstJurisdiction },
+      props: { entry, entryJurisdictions, relatedEntries },
     };
   });
 }
 
-interface Props {
-  entry: CollectionEntry<"directory">;
-  entryJurisdictions: { id: string; name: string }[];
-  relatedEntries: RelatedEntry[];
-  firstJurisdiction: { id: string; name: string } | undefined;
-}
-
-const { entry, entryJurisdictions, relatedEntries, firstJurisdiction } =
-  Astro.props;
+const { entry, entryJurisdictions, relatedEntries } = Astro.props;
+const firstJurisdiction = entryJurisdictions[0];
 const { name, description, services, email, phone, url, logo } = entry.data;
 ---
 
@@ -87,27 +80,17 @@ const { name, description, services, email, phone, url, logo } = entry.data;
     <dl class="entry-meta">
       <dt>Services</dt>
       <dd>
-        {
-          services.map((svc, i) => (
-            <>
-              <a href={`/directory?service=${svc}`}>
-                {SERVICE_LABELS[svc as Service] ?? svc}
-              </a>
-              {i < services.length - 1 ? ", " : ""}
-            </>
-          ))
-        }
+        <InlineLinkList items={services.map((svc) => ({
+          name: SERVICE_LABELS[svc as Service] ?? svc,
+          href: `/directory?service=${svc}`,
+        }))} />
       </dd>
       <dt>{entryJurisdictions.length > 1 ? "States" : "State"}</dt>
       <dd>
-        {
-          entryJurisdictions.map((j, i) => (
-            <>
-              <a href={`/directory?state=${j.id}`}>{j.name}</a>
-              {i < entryJurisdictions.length - 1 ? ", " : ""}
-            </>
-          ))
-        }
+        <InlineLinkList items={entryJurisdictions.map((jurisdiction) => ({
+          name: jurisdiction.name,
+          href: `/directory?state=${jurisdiction.id}`,
+        }))} />
       </dd>
       {
         url && (
@@ -141,13 +124,15 @@ const { name, description, services, email, phone, url, logo } = entry.data;
       }
     </dl>
   </section>
-  {firstJurisdiction && (
-    <RelatedDirectoryEntries
-      entries={relatedEntries}
-      stateId={firstJurisdiction.id}
-      stateName={firstJurisdiction.name}
-    />
-  )}
+  {
+    firstJurisdiction && (
+      <RelatedDirectoryEntries
+        entries={relatedEntries}
+        stateId={firstJurisdiction.id}
+        stateName={firstJurisdiction.name}
+      />
+    )
+  }
 </BaseLayout>
 
 <style>
@@ -172,15 +157,5 @@ const { name, description, services, email, phone, url, logo } = entry.data;
       margin-block-end: var(--space-s);
     }
 
-    a {
-      color: var(--text-color);
-      text-decoration: none;
-
-      @media (hover: hover) {
-        &:hover {
-          text-decoration: underline;
-        }
-      }
-    }
   }
 </style>

--- a/web/src/pages/directory/[slug].astro
+++ b/web/src/pages/directory/[slug].astro
@@ -133,7 +133,7 @@ const { name, description, services, email, phone, url, logo } = entry.data;
       <RelatedDirectoryEntries
         entries={relatedEntries}
         stateId={firstJurisdiction.id}
-        stateName={firstJurisdiction.name}
+        heading={`Also in ${firstJurisdiction.name}`}
       />
     )
   }

--- a/web/src/pages/directory/[slug].astro
+++ b/web/src/pages/directory/[slug].astro
@@ -62,7 +62,7 @@ const { name, description, services, email, phone, url, logo } = entry.data;
   <PageHeader
     title={name}
     description={description}
-    annotation="underline"
+    annotation={null}
     breadcrumbs={[{ label: "Directory", href: "/directory" }]}
   >
     {
@@ -80,17 +80,21 @@ const { name, description, services, email, phone, url, logo } = entry.data;
     <dl class="entry-meta">
       <dt>Services</dt>
       <dd>
-        <InlineLinkList items={services.map((svc) => ({
-          name: SERVICE_LABELS[svc as Service] ?? svc,
-          href: `/directory?service=${svc}`,
-        }))} />
+        <InlineLinkList
+          items={services.map((svc) => ({
+            name: SERVICE_LABELS[svc as Service] ?? svc,
+            href: `/directory?service=${svc}`,
+          }))}
+        />
       </dd>
       <dt>{entryJurisdictions.length > 1 ? "States" : "State"}</dt>
       <dd>
-        <InlineLinkList items={entryJurisdictions.map((jurisdiction) => ({
-          name: jurisdiction.name,
-          href: `/directory?state=${jurisdiction.id}`,
-        }))} />
+        <InlineLinkList
+          items={entryJurisdictions.map((jurisdiction) => ({
+            name: jurisdiction.name,
+            href: `/directory?state=${jurisdiction.id}`,
+          }))}
+        />
       </dd>
       {
         url && (
@@ -156,6 +160,5 @@ const { name, description, services, email, phone, url, logo } = entry.data;
       margin: 0;
       margin-block-end: var(--space-s);
     }
-
   }
 </style>

--- a/web/src/pages/directory/index.astro
+++ b/web/src/pages/directory/index.astro
@@ -1,7 +1,6 @@
 ---
 export const prerender = false;
 
-import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
 import {
   RiGlobalLine,
@@ -10,6 +9,7 @@ import {
   RiPhoneLine,
   RiVerifiedBadgeFill,
 } from "@remixicon/react";
+import DirectoryLogo from "#components/DirectoryLogo.astro";
 import PageHeader from "#components/PageHeader.astro";
 import { SERVICE_LABELS, SERVICES, type Service } from "#constants/services";
 import BaseLayout from "#layouts/BaseLayout.astro";
@@ -115,12 +115,9 @@ const description =
         <ul class="directory-list-items">
           {contacts.map((c) => (
             <li class="directory-list-item">
-              {c.logo &&
-                (c.logo.format === "svg" ? (
-                  <img class="logo" src={c.logo.src} alt={`${c.name} logo`} />
-                ) : (
-                  <Image class="logo" src={c.logo} alt={`${c.name} logo`} />
-                ))}
+              {c.logo && (
+                <DirectoryLogo logo={c.logo} name={c.name} class="logo" />
+              )}
               <header>
                 {c.officialPartner && (
                   <div class="badge">
@@ -128,7 +125,9 @@ const description =
                     Namesake Partner
                   </div>
                 )}
-                <h2>{c.name}</h2>
+                <h2>
+                  <a href={`/directory/${c.slug}`}>{c.name}</a>
+                </h2>
                 <p class="description">{c.description}</p>
               </header>
               <ul class="services" aria-label="Services">
@@ -374,13 +373,6 @@ const description =
     padding-block-end: var(--space-2xl);
     break-inside: avoid;
 
-    .logo {
-      width: auto;
-      max-height: 64px;
-      mix-blend-mode: multiply;
-      filter: grayscale(100%);
-    }
-
     header {
       display: flex;
       flex-direction: column;
@@ -392,6 +384,17 @@ const description =
       font-size: var(--step-1);
       line-height: var(--line-height-display);
       text-wrap: balance;
+
+      a {
+        color: inherit;
+        text-decoration: none;
+
+        @media (hover: hover) {
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
     }
 
     .description {
@@ -416,6 +419,10 @@ const description =
         width: 1rem;
         height: 1rem;
       }
+    }
+
+    .logo {
+      max-height: 64px;
     }
 
     .services {

--- a/web/src/pages/directory/index.astro
+++ b/web/src/pages/directory/index.astro
@@ -10,6 +10,7 @@ import {
   RiVerifiedBadgeFill,
 } from "@remixicon/react";
 import DirectoryLogo from "#components/DirectoryLogo.astro";
+import InlineLinkList from "#components/InlineLinkList.astro";
 import PageHeader from "#components/PageHeader.astro";
 import { SERVICE_LABELS, SERVICES, type Service } from "#constants/services";
 import BaseLayout from "#layouts/BaseLayout.astro";
@@ -40,12 +41,13 @@ const contacts = filteredEntries.map(({ id, data }) => ({
   name: data.name,
   description: data.description,
   jurisdictions: data.jurisdictions
-    .map(
-      (ref) =>
+    .map((ref) => ({
+      id: ref.id,
+      name:
         jurisdictionsCollection.find((j) => j.id === ref.id)?.data.name ??
         ref.id,
-    )
-    .sort(),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name)),
   services: data.services,
   officialPartner: data.officialPartner,
   email: data.email,
@@ -113,56 +115,69 @@ const description =
     {
       contacts.length ? (
         <ul class="directory-list-items">
-          {contacts.map((c) => (
+          {contacts.map((contact) => (
             <li class="directory-list-item">
-              {c.logo && (
-                <DirectoryLogo logo={c.logo} name={c.name} class="logo" />
+              {contact.logo && (
+                <DirectoryLogo
+                  logo={contact.logo}
+                  name={contact.name}
+                  class="logo"
+                />
               )}
               <header>
-                {c.officialPartner && (
+                {contact.officialPartner && (
                   <div class="badge">
                     <RiVerifiedBadgeFill size={16} />
                     Namesake Partner
                   </div>
                 )}
                 <h2>
-                  <a href={`/directory/${c.slug}`}>{c.name}</a>
+                  <a href={`/directory/${contact.slug}`}>{contact.name}</a>
                 </h2>
-                <p class="description">{c.description}</p>
+                <p class="description">{contact.description}</p>
               </header>
               <ul class="services" aria-label="Services">
-                {c.services.map((svc) => (
-                  <li>{SERVICE_LABELS[svc as Service] ?? svc}</li>
+                {contact.services.map((svc) => (
+                  <li>
+                    <a href={`/directory?service=${svc}`}>
+                      {SERVICE_LABELS[svc as Service] ?? svc}
+                    </a>
+                  </li>
                 ))}
               </ul>
               <ul class="contact-info">
                 <li>
                   <RiMapPinLine size={18} />
                   <div class="contact-label">
-                    <span>{c.jurisdictions.join(", ")}</span>
+                    <InlineLinkList
+                      items={contact.jurisdictions.map((jurisdiction) => ({
+                        name: jurisdiction.name,
+                        href: `/directory?state=${jurisdiction.id}`,
+                      }))}
+                    />
                   </div>
                 </li>
-                {c.url && (
+                {contact.url && (
                   <li>
                     <RiGlobalLine size={18} />
                     <div class="contact-label">
-                      <a href={c.url}>{formatCleanUrl(c.url)}</a>
+                      <a href={contact.url}>{formatCleanUrl(contact.url)}</a>
                     </div>
                   </li>
                 )}
-                {c.email && (
+                {contact.email && (
                   <li>
                     <RiMailSendLine size={18} />
                     <div class="contact-label">
-                      <a href={`mailto:${c.email}`}>{c.email}</a>
+                      <a href={`mailto:${contact.email}`}>{contact.email}</a>
                     </div>
                   </li>
                 )}
-                {c.phone && (
+                {contact.phone && (
                   <li>
                     <RiPhoneLine size={18} />
                     <div class="contact-label">
-                      <a href={`tel:${c.phone}`}>{c.phone}</a>
+                      <a href={`tel:${contact.phone}`}>{contact.phone}</a>
                     </div>
                   </li>
                 )}
@@ -434,11 +449,16 @@ const description =
       list-style: none;
 
       li {
-        padding: 0.15em 0.5em;
-        font-size: var(--step--1);
-        white-space: nowrap;
-        border: 1px solid var(--border-color);
-        border-left-width: 3px;
+        a {
+          display: inline-block;
+          color: inherit;
+          padding: 0.15em 0.5em;
+          font-size: var(--step--1);
+          white-space: nowrap;
+          border: 1px solid var(--border-color);
+          border-left-width: 3px;
+          text-decoration: none;
+        }
       }
     }
 
@@ -454,12 +474,13 @@ const description =
         grid-template-areas: "icon label";
         grid-template-columns: 1.15rem 1fr;
         gap: var(--space-2xs);
+        padding-block-end: var(--space-2xs);
         max-width: 100%;
 
         > svg {
           flex-shrink: 0;
           grid-area: icon;
-          margin-top: 0.3em;
+          margin-top: 0.2em;
         }
 
         .contact-label {
@@ -470,7 +491,6 @@ const description =
           > a {
             display: block;
             width: fit-content;
-            padding-block: 0.15em;
           }
 
           a {

--- a/web/src/pages/guides/[jurisdiction].astro
+++ b/web/src/pages/guides/[jurisdiction].astro
@@ -3,12 +3,18 @@ import { getCollection } from "astro:content";
 import type { BreadcrumbItem } from "#components/Breadcrumbs.astro";
 import GuideLinkGroup from "#components/GuideLinkGroup.astro";
 import PageHeader from "#components/PageHeader.astro";
+import RelatedDirectoryEntries, {
+  type RelatedEntry,
+} from "#components/RelatedDirectoryEntries.astro";
 import { siteInfo } from "#constants/site-info";
 import BaseLayout from "#layouts/BaseLayout.astro";
 import { getGuidesByJurisdiction } from "#lib/queries/guides";
 
 export async function getStaticPaths() {
-  const allJurisdictions = await getCollection("jurisdictions");
+  const [allJurisdictions, allDirectoryEntries] = await Promise.all([
+    getCollection("jurisdictions"),
+    getCollection("directory"),
+  ]);
   const { guidesByJurisdiction } = await getGuidesByJurisdiction();
 
   const guideMap = new Map(
@@ -18,16 +24,35 @@ export async function getStaticPaths() {
     ]),
   );
 
-  return allJurisdictions.map((jurisdiction) => ({
-    params: { jurisdiction: jurisdiction.id },
-    props: {
-      jurisdiction,
-      guides: guideMap.get(jurisdiction.id) ?? [],
-    },
-  }));
+  return allJurisdictions.map((jurisdiction) => {
+    const directoryEntries: RelatedEntry[] = allDirectoryEntries
+      .filter((entry) =>
+        entry.data.jurisdictions.some((ref) => ref.id === jurisdiction.id),
+      )
+      .sort((a, b) => {
+        if (a.data.officialPartner !== b.data.officialPartner)
+          return a.data.officialPartner ? -1 : 1;
+        return a.data.name.localeCompare(b.data.name);
+      })
+      .map((entry) => ({
+        id: entry.id,
+        name: entry.data.name,
+        description: entry.data.description,
+        logo: entry.data.logo,
+      }));
+
+    return {
+      params: { jurisdiction: jurisdiction.id },
+      props: {
+        jurisdiction,
+        guides: guideMap.get(jurisdiction.id) ?? [],
+        directoryEntries,
+      },
+    };
+  });
 }
 
-const { jurisdiction, guides } = Astro.props;
+const { jurisdiction, guides, directoryEntries } = Astro.props;
 const hasGuides = guides.length > 0;
 
 const searchTitle = `${jurisdiction.data.name}: All Guides`;
@@ -72,6 +97,11 @@ const description = hasGuides
       </div>
     )
   }
+  <RelatedDirectoryEntries
+    entries={directoryEntries}
+    stateId={jurisdiction.id}
+    heading={`${jurisdiction.data.name} support`}
+  />
 </BaseLayout>
 
 <style>


### PR DESCRIPTION
- Add unique pages for each directory entry, e.g. namesake.fyi/directory/mtpc.
- Link to child pages by clicking on the title on the directory index
- Display up to 3 related entries which are available in the same state
- Componentize the `DirectoryLogo` logic for reuse
- Allow filtering directory by clicking on state names
- Allow filtering directory by clicking on service tags