### PR TITLE
Use title with jurisdiction for guide page titles

### DIFF
--- a/web/src/constants/jurisdictions.ts
+++ b/web/src/constants/jurisdictions.ts
@@ -73,6 +73,7 @@ export const JURISDICTIONS = {
 >;
 
 export type JurisdictionId = keyof typeof JURISDICTIONS;
+export type JurisdictionName = (typeof JURISDICTIONS)[JurisdictionId]["name"];
 
 export const JURISDICTION_OPTIONS = Object.entries(JURISDICTIONS).map(
   ([id, jurisdiction]) => ({

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -5,7 +5,7 @@ import { ANNOTATION_TYPES } from "./constants/annotations";
 import { CATEGORIES } from "./constants/categories";
 import { COLOR_KEYS } from "./constants/colors";
 import type { FormConfig } from "./constants/forms";
-import { JURISDICTIONS } from "./constants/jurisdictions";
+import { JURISDICTIONS, type JurisdictionId } from "./constants/jurisdictions";
 import type { PDFDefinition } from "./constants/pdf";
 import { SERVICES } from "./constants/services";
 
@@ -120,7 +120,7 @@ const jurisdictions = defineCollection({
       namesakeSupport: jurisdiction.namesakeSupport,
     })),
   schema: z.object({
-    name: z.string(),
+    name: z.string<JurisdictionId>(),
     territory: z.boolean(),
     namesakeSupport: z.enum(["full", "prioritized", "none"]),
   }),

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -5,7 +5,10 @@ import { ANNOTATION_TYPES } from "./constants/annotations";
 import { CATEGORIES } from "./constants/categories";
 import { COLOR_KEYS } from "./constants/colors";
 import type { FormConfig } from "./constants/forms";
-import { JURISDICTIONS, type JurisdictionId } from "./constants/jurisdictions";
+import {
+  JURISDICTIONS,
+  type JurisdictionName,
+} from "./constants/jurisdictions";
 import type { PDFDefinition } from "./constants/pdf";
 import { SERVICES } from "./constants/services";
 
@@ -120,7 +123,7 @@ const jurisdictions = defineCollection({
       namesakeSupport: jurisdiction.namesakeSupport,
     })),
   schema: z.object({
-    name: z.string<JurisdictionId>(),
+    name: z.string<JurisdictionName>(),
     territory: z.boolean(),
     namesakeSupport: z.enum(["full", "prioritized", "none"]),
   }),

--- a/web/src/lib/utils/__tests__/formatTitleWithJurisdiction.test.ts
+++ b/web/src/lib/utils/__tests__/formatTitleWithJurisdiction.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { formatTitleWithJurisdiction } from "../formatTitleWithJurisdiction";
+
+describe("formatTitleWithJurisdiction", () => {
+  it("renders the title correctly with the jurisdiction", () => {
+    expect(formatTitleWithJurisdiction("Court Order", "Massachusetts")).toEqual(
+      "Massachusetts Court Order",
+    );
+  });
+
+  it("renders the title correctly without the jurisdiction", () => {
+    expect(formatTitleWithJurisdiction("Passport")).toEqual("Passport");
+  });
+});

--- a/web/src/lib/utils/formatTitleWithJurisdiction.ts
+++ b/web/src/lib/utils/formatTitleWithJurisdiction.ts
@@ -1,4 +1,4 @@
-import type { JurisdictionId } from "#constants/jurisdictions.ts";
+import type { JurisdictionName } from "#constants/jurisdictions.ts";
 
 /**
  * Given a title and jurisdiction
@@ -10,7 +10,7 @@ import type { JurisdictionId } from "#constants/jurisdictions.ts";
  */
 export function formatTitleWithJurisdiction(
   title: string,
-  jurisdiction?: JurisdictionId,
+  jurisdiction?: JurisdictionName,
 ) {
   return `${jurisdiction ? `${jurisdiction} ` : ""}${title}`;
 }

--- a/web/src/lib/utils/formatTitleWithJurisdiction.ts
+++ b/web/src/lib/utils/formatTitleWithJurisdiction.ts
@@ -1,0 +1,14 @@
+/**
+ * Given a title and jurisdiction
+ * return the full string to display in the page title.
+ *
+ * @example
+ * formatPageTitle("Court Order", "Massachusetts")
+ * // "Massachusetts Court Order"
+ */
+export function formatTitleWithJurisdiction(
+  title: string,
+  jurisdiction: string,
+) {
+  return `${jurisdiction} ${title}`;
+}

--- a/web/src/lib/utils/formatTitleWithJurisdiction.ts
+++ b/web/src/lib/utils/formatTitleWithJurisdiction.ts
@@ -1,3 +1,5 @@
+import type { JurisdictionId } from "#constants/jurisdictions.ts";
+
 /**
  * Given a title and jurisdiction
  * return the full string to display in the page title.
@@ -8,7 +10,7 @@
  */
 export function formatTitleWithJurisdiction(
   title: string,
-  jurisdiction: string,
+  jurisdiction?: JurisdictionId,
 ) {
-  return `${jurisdiction} ${title}`;
+  return `${jurisdiction ? `${jurisdiction} ` : ""}${title}`;
 }

--- a/web/src/pages/guides/[...slug].astro
+++ b/web/src/pages/guides/[...slug].astro
@@ -21,9 +21,10 @@ const jurisdiction = guide.data.jurisdiction
   ? await getEntry(guide.data.jurisdiction)
   : null;
 
-const title = jurisdiction
-  ? formatTitleWithJurisdiction(guide.data.title, jurisdiction.data.name)
-  : guide.data.title;
+const title = formatTitleWithJurisdiction(
+  guide.data.title,
+  jurisdiction?.data.name,
+);
 ---
 
 <ProseLayout

--- a/web/src/pages/guides/[...slug].astro
+++ b/web/src/pages/guides/[...slug].astro
@@ -20,14 +20,13 @@ const jurisdiction = guide.data.jurisdiction
   ? await getEntry(guide.data.jurisdiction)
   : null;
 
-const searchTitle = jurisdiction
+const title = jurisdiction
   ? `${jurisdiction.data.name}: ${guide.data.title}`
   : guide.data.title;
 ---
 
 <ProseLayout
-  title={guide.data.title}
-  searchTitle={searchTitle}
+  title={title}
   description={guide.data.description}
   annotation="box"
   breadcrumbs={[

--- a/web/src/pages/guides/[...slug].astro
+++ b/web/src/pages/guides/[...slug].astro
@@ -5,6 +5,7 @@ import GuideFooter from "#components/GuideFooter.astro";
 import StubBanner from "#components/StubBanner.astro";
 import TableOfContents from "#components/TableOfContents.astro";
 import ProseLayout from "#layouts/ProseLayout.astro";
+import { formatTitleWithJurisdiction } from "#lib/utils/formatTitleWithJurisdiction.ts";
 
 export async function getStaticPaths() {
   const guides = await getCollection("guides", ({ data }) => !data.unlisted);
@@ -21,7 +22,7 @@ const jurisdiction = guide.data.jurisdiction
   : null;
 
 const title = jurisdiction
-  ? `${jurisdiction.data.name}: ${guide.data.title}`
+  ? formatTitleWithJurisdiction(guide.data.title, jurisdiction.data.name)
   : guide.data.title;
 ---
 


### PR DESCRIPTION
Uses the existing `searchTitle` format as the primary page title, so that the metadata title used for the page (e.g. in search results or tab names) includes the relevant jurisdiction, such as `Massachusetts: Court Order · Namesake`.