### PR TITLE
Align state guide descriptions

### DIFF
--- a/web/src/content/guides/ma/birth-certificate.mdx
+++ b/web/src/content/guides/ma/birth-certificate.mdx
@@ -1,5 +1,6 @@
 ---
 title: Birth Certificate
+description: Here's how to update your Massachusetts birth certificate.
 jurisdiction: ma
 category: birth-certificate
 ---

--- a/web/src/content/guides/ma/court-order.mdx
+++ b/web/src/content/guides/ma/court-order.mdx
@@ -1,6 +1,6 @@
 ---
 title: Court Order
-description: Getting a court order is the first step to take when changing your name.
+description: Getting a court order is the first step to take when changing your name in Massachusetts.
 jurisdiction: ma
 category: court-order
 ---

--- a/web/src/content/guides/ma/state-id.mdx
+++ b/web/src/content/guides/ma/state-id.mdx
@@ -1,6 +1,6 @@
 ---
 title: State ID
-description: Updating your ID or Driver's License requires making an appointment at the RMV.
+description: Here's how to update your Massachusetts state ID or driver's license.
 jurisdiction: ma
 category: state-id
 ---

--- a/web/src/content/guides/ri/court-order.mdx
+++ b/web/src/content/guides/ri/court-order.mdx
@@ -1,6 +1,6 @@
 ---
 title: Court Order
-description: Getting a court order is the first step to take when changing your name.
+description: Getting a court order is the first step to take when changing your name in Rhode Island.
 jurisdiction: ri
 category: court-order
 ---


### PR DESCRIPTION
Just putting this out here as a thing I noticed while looking around for #706 - most of the Rhode Island guides include the state name in the description, which might be helpful in terms of SEO. It also looks like there was a missing description in the case of the MA birth certificate, and a kinda overly detailed description for the MA state id. 