### PR TITLE
Show document names in embedded guide forms

### DIFF
--- a/docs/src/content/docs/guides/building-forms.mdx
+++ b/docs/src/content/docs/guides/building-forms.mdx
@@ -152,9 +152,11 @@ In your guide, render `FormContainer` with your form's `slug`:
 ```mdx
 // court-order.mdx
 
+import FormContainer from "#components/forms/FormContainer/FormContainer.astro"
+
 ## Fill out forms
 
-<FormContainer client:load slug="court-order-ma" inline />
+<FormContainer slug="court-order-ma" />
 ```
 
 ## Connect PDF fields

--- a/docs/src/content/docs/guides/writing.mdx
+++ b/docs/src/content/docs/guides/writing.mdx
@@ -207,17 +207,17 @@ Namesake uses guided [forms](https://namesake.fyi/forms) to help users fill out 
 ```mdx wrap
 # court-order.mdx
 
-import { FormContainer } from "#components/forms/FormContainer/index.ts"
+import FormContainer from "#components/forms/FormContainer/FormContainer.astro"
 ```
 
-`Formcontainer` accepts a `slug` and should be set to `client:load` and `inline` for proper rendering within guides:
+`FormContainer` accepts a `slug` and renders inline within guides by default:
 
 ```mdx wrap
 # court-order.mdx
 
 ## Fill out forms
 
-<FormContainer client:load slug="court-order-ma" inline />
+<FormContainer slug="court-order-ma" />
 ```
 
 ### Display maps beside addresses

--- a/web/src/components/forms/FormContainer/FormContainer.astro
+++ b/web/src/components/forms/FormContainer/FormContainer.astro
@@ -8,15 +8,15 @@ interface Props {
   inline?: boolean;
 }
 
-const { slug, inline = false } = Astro.props;
-const initialPdfs = await getFormPdfMetadata(slug);
+const { slug, inline = true } = Astro.props;
+const pdfMetadata = await getFormPdfMetadata(slug);
 ---
 
 <ReactFormContainer
   client:load
   slug={slug}
   inline={inline}
-  initialPdfs={initialPdfs}
+  pdfMetadata={pdfMetadata}
 >
   <slot />
 </ReactFormContainer>

--- a/web/src/components/forms/FormContainer/FormContainer.astro
+++ b/web/src/components/forms/FormContainer/FormContainer.astro
@@ -1,0 +1,22 @@
+---
+import type { FormSlug } from "#constants/forms";
+import { getFormPdfMetadata } from "#lib/forms/getFormPdfMetadata";
+import { FormContainer as ReactFormContainer } from "./FormContainer";
+
+interface Props {
+  slug: FormSlug;
+  inline?: boolean;
+}
+
+const { slug, inline = false } = Astro.props;
+const initialPdfs = await getFormPdfMetadata(slug);
+---
+
+<ReactFormContainer
+  client:load
+  slug={slug}
+  inline={inline}
+  initialPdfs={initialPdfs}
+>
+  <slot />
+</ReactFormContainer>

--- a/web/src/components/forms/FormContainer/FormContainer.test.tsx
+++ b/web/src/components/forms/FormContainer/FormContainer.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FormConfig } from "#constants/forms";
 import * as db from "#db/database";
+import { getFormPdfMetadata } from "#lib/forms/getFormPdfMetadata";
 import type { Step } from "#lib/forms/types";
 import { FormStep } from "../FormStep/FormStep";
 import { FormContainer } from "./FormContainer";
@@ -93,6 +94,26 @@ describe("FormContainer", () => {
       expect(
         await screen.findByRole("button", { name: "Start" }),
       ).toBeInTheDocument();
+    });
+
+    it("renders initial PDF metadata without loading it on the client", async () => {
+      render(
+        <FormContainer
+          slug="court-order-ma"
+          initialPdfs={[
+            {
+              pdfId: "cjp27-petition-to-change-name-of-adult",
+              title: "Petition to Change Name of Adult",
+              code: "CJP-27",
+            },
+          ]}
+        />,
+      );
+
+      expect(
+        await screen.findByText("Petition to Change Name of Adult (CJP-27)"),
+      ).toBeInTheDocument();
+      expect(getFormPdfMetadata).not.toHaveBeenCalled();
     });
 
     it("renders a loading spinner while saved progress is being fetched", async () => {

--- a/web/src/components/forms/FormContainer/FormContainer.test.tsx
+++ b/web/src/components/forms/FormContainer/FormContainer.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FormConfig } from "#constants/forms";
 import * as db from "#db/database";
-import { getFormPdfMetadata } from "#lib/forms/getFormPdfMetadata";
 import type { Step } from "#lib/forms/types";
 import { FormStep } from "../FormStep/FormStep";
 import { FormContainer } from "./FormContainer";
@@ -19,9 +18,6 @@ vi.mock("#db/database", () => ({
 }));
 
 vi.mock("#lib/forms/getFormConfig");
-vi.mock("#lib/forms/getFormPdfMetadata", () => ({
-  getFormPdfMetadata: vi.fn().mockResolvedValue([]),
-}));
 
 import { getFormConfig } from "#lib/forms/getFormConfig";
 
@@ -96,11 +92,11 @@ describe("FormContainer", () => {
       ).toBeInTheDocument();
     });
 
-    it("renders initial PDF metadata without loading it on the client", async () => {
+    it("renders PDF metadata provided by the Astro wrapper", async () => {
       render(
         <FormContainer
           slug="court-order-ma"
-          initialPdfs={[
+          pdfMetadata={[
             {
               pdfId: "cjp27-petition-to-change-name-of-adult",
               title: "Petition to Change Name of Adult",
@@ -113,7 +109,6 @@ describe("FormContainer", () => {
       expect(
         await screen.findByText("Petition to Change Name of Adult (CJP-27)"),
       ).toBeInTheDocument();
-      expect(getFormPdfMetadata).not.toHaveBeenCalled();
     });
 
     it("renders a loading spinner while saved progress is being fetched", async () => {

--- a/web/src/components/forms/FormContainer/FormContainer.tsx
+++ b/web/src/components/forms/FormContainer/FormContainer.tsx
@@ -1,12 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { FormProvider } from "react-hook-form";
 import type { FormSlug } from "#constants/forms";
 import { createFormSubmitHandler } from "#lib/forms/createFormSubmitHandler";
 import { getFormConfig } from "#lib/forms/getFormConfig";
-import {
-  type FormPdfMetadata,
-  getFormPdfMetadata,
-} from "#lib/forms/getFormPdfMetadata";
+import type { FormPdfMetadata } from "#lib/forms/getFormPdfMetadata";
 import { useFormData } from "#lib/forms/useFormData";
 import { useFormState } from "#lib/forms/useFormState";
 import { ProgressCircle } from "../../common/ProgressCircle";
@@ -24,7 +21,7 @@ export interface FormContainerProps {
   inline?: boolean;
 
   /** PDF metadata rendered by Astro and passed into hydrated form islands. */
-  initialPdfs?: FormPdfMetadata[];
+  pdfMetadata?: FormPdfMetadata[];
 
   /** Optional content to render on the title step (e.g. a <Banner>). */
   children?: React.ReactNode;
@@ -33,18 +30,13 @@ export interface FormContainerProps {
 export function FormContainer({
   slug,
   inline = false,
-  initialPdfs,
+  pdfMetadata = [],
   children,
 }: FormContainerProps) {
   const config = getFormConfig(slug);
   if (!config) throw new Error(`No form config found for slug: ${slug}`);
   const { title, description, costs, steps } = config;
 
-  const [pdfs, setPdfs] = useState<FormPdfMetadata[]>(initialPdfs ?? []);
-  useEffect(() => {
-    if (initialPdfs && initialPdfs.length > 0) return;
-    getFormPdfMetadata(slug).then(setPdfs);
-  }, [slug, initialPdfs]);
   const form = useFormData(config);
   const onSubmit = createFormSubmitHandler(config, form);
 
@@ -152,7 +144,7 @@ export function FormContainer({
           <FormTitleStep
             title={title}
             description={description}
-            pdfs={pdfs ?? []}
+            pdfs={pdfMetadata}
             totalSteps={totalSteps}
             onStart={onStart}
             headingLevel={inline ? 2 : 1}
@@ -186,7 +178,7 @@ export function FormContainer({
     phase,
     steps,
     activeStep,
-    pdfs,
+    pdfMetadata,
     title,
     description,
     children,

--- a/web/src/components/forms/FormContainer/FormContainer.tsx
+++ b/web/src/components/forms/FormContainer/FormContainer.tsx
@@ -23,6 +23,9 @@ export interface FormContainerProps {
   /** Render inline within a page rather than as a full-page experience. */
   inline?: boolean;
 
+  /** PDF metadata rendered by Astro and passed into hydrated form islands. */
+  initialPdfs?: FormPdfMetadata[];
+
   /** Optional content to render on the title step (e.g. a <Banner>). */
   children?: React.ReactNode;
 }
@@ -30,16 +33,18 @@ export interface FormContainerProps {
 export function FormContainer({
   slug,
   inline = false,
+  initialPdfs,
   children,
 }: FormContainerProps) {
   const config = getFormConfig(slug);
   if (!config) throw new Error(`No form config found for slug: ${slug}`);
   const { title, description, costs, steps } = config;
 
-  const [pdfs, setPdfs] = useState<FormPdfMetadata[]>([]);
+  const [pdfs, setPdfs] = useState<FormPdfMetadata[]>(initialPdfs ?? []);
   useEffect(() => {
+    if (initialPdfs && initialPdfs.length > 0) return;
     getFormPdfMetadata(slug).then(setPdfs);
-  }, [slug]);
+  }, [slug, initialPdfs]);
   const form = useFormData(config);
   const onSubmit = createFormSubmitHandler(config, form);
 

--- a/web/src/content/guides/ma/birth-certificate.mdx
+++ b/web/src/content/guides/ma/birth-certificate.mdx
@@ -29,7 +29,7 @@ In most cases, no. A birth certificate matching your current name and gender mar
 
 Once finished, a PDF will be downloaded for you to review and sign.
 
-<FormContainer slug="birth-certificate-affidavit-ma" inline />
+<FormContainer slug="birth-certificate-affidavit-ma" />
 
 ## Gather funds or waive fees
 

--- a/web/src/content/guides/ma/birth-certificate.mdx
+++ b/web/src/content/guides/ma/birth-certificate.mdx
@@ -6,7 +6,7 @@ category: birth-certificate
 ---
 
 import Costs from "#components/Costs.astro";
-import { FormContainer } from "#components/forms/FormContainer/index.ts";
+import FormContainer from "#components/forms/FormContainer/FormContainer.astro";
 
 ## Get prepared
 
@@ -29,7 +29,7 @@ In most cases, no. A birth certificate matching your current name and gender mar
 
 Once finished, a PDF will be downloaded for you to review and sign.
 
-<FormContainer client:load slug="birth-certificate-affidavit-ma" inline />
+<FormContainer slug="birth-certificate-affidavit-ma" inline />
 
 ## Gather funds or waive fees
 

--- a/web/src/content/guides/ma/court-order.mdx
+++ b/web/src/content/guides/ma/court-order.mdx
@@ -6,7 +6,7 @@ category: court-order
 ---
 
 import Costs from "#components/Costs.astro"
-import { FormContainer } from "#components/forms/FormContainer/index.ts"
+import FormContainer from "#components/forms/FormContainer/FormContainer.astro"
 import { Content as NotarySnippet } from "#content/snippets/notaries.md"
 
 ## Get prepared
@@ -43,7 +43,7 @@ Birth certificates that are not written in English must include a written transl
 
 Namesake will walk you through all of the questions required to fill out forms for the court. Once finished, a PDF will be downloaded for you to review and sign.
 
-<FormContainer client:load slug="court-order-ma" inline />
+<FormContainer slug="court-order-ma" inline />
 
 ## Review and print documents
 
@@ -68,7 +68,7 @@ An Affidavit of Indigency is a fancy way of saying fee waiver. If you qualify by
 
 </details>
 
-<FormContainer client:load slug="affidavit-of-indigency-ma" inline />
+<FormContainer slug="affidavit-of-indigency-ma" inline />
 
 ## File documents
 

--- a/web/src/content/guides/ma/court-order.mdx
+++ b/web/src/content/guides/ma/court-order.mdx
@@ -43,7 +43,7 @@ Birth certificates that are not written in English must include a written transl
 
 Namesake will walk you through all of the questions required to fill out forms for the court. Once finished, a PDF will be downloaded for you to review and sign.
 
-<FormContainer slug="court-order-ma" inline />
+<FormContainer slug="court-order-ma" />
 
 ## Review and print documents
 
@@ -68,7 +68,7 @@ An Affidavit of Indigency is a fancy way of saying fee waiver. If you qualify by
 
 </details>
 
-<FormContainer slug="affidavit-of-indigency-ma" inline />
+<FormContainer slug="affidavit-of-indigency-ma" />
 
 ## File documents
 

--- a/web/src/content/guides/ri/court-order.mdx
+++ b/web/src/content/guides/ri/court-order.mdx
@@ -57,7 +57,7 @@ You can also use a shelter’s address when filing your name change petition. Rh
 
 ## Fill out forms
 
-<FormContainer slug="court-order-ri" inline />
+<FormContainer slug="court-order-ri" />
 
 ## Review and print documents
 

--- a/web/src/content/guides/ri/court-order.mdx
+++ b/web/src/content/guides/ri/court-order.mdx
@@ -5,7 +5,7 @@ jurisdiction: ri
 category: court-order
 ---
 
-import { FormContainer } from "#components/forms/FormContainer/index.ts"
+import FormContainer from "#components/forms/FormContainer/FormContainer.astro"
 import MapEmbed from "#components/MapEmbed.astro"
 import { Content as NotarySnippet } from "#content/snippets/notaries.md"
 
@@ -57,7 +57,7 @@ You can also use a shelter’s address when filing your name change petition. Rh
 
 ## Fill out forms
 
-<FormContainer client:load slug="court-order-ri" inline />
+<FormContainer slug="court-order-ri" inline />
 
 ## Review and print documents
 

--- a/web/src/content/guides/social-security.mdx
+++ b/web/src/content/guides/social-security.mdx
@@ -48,7 +48,7 @@ We’ll walk you through the process of filling out the required form.
 
 Please note: Namesake does not ask you to enter your social security number, or the social security number of parents. Once the form is complete, you’ll need to fill those out yourself and sign the document.
 
-<FormContainer slug="social-security" inline />
+<FormContainer slug="social-security" />
 
 ## Make an appointment
 

--- a/web/src/content/guides/social-security.mdx
+++ b/web/src/content/guides/social-security.mdx
@@ -4,7 +4,7 @@ description: Changing your name with Social Security is required to update some 
 category: social-security
 ---
 
-import { FormContainer } from "#components/forms/FormContainer/index.ts"
+import FormContainer from "#components/forms/FormContainer/FormContainer.astro"
 
 ## Get prepared
 
@@ -48,7 +48,7 @@ We’ll walk you through the process of filling out the required form.
 
 Please note: Namesake does not ask you to enter your social security number, or the social security number of parents. Once the form is complete, you’ll need to fill those out yourself and sign the document.
 
-<FormContainer client:load slug="social-security" inline />
+<FormContainer slug="social-security" inline />
 
 ## Make an appointment
 

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -46,12 +46,6 @@ const pageTitle = Astro.url.pathname === "/" ? title : `${title} · Namesake`;
       import * as Fathom from "fathom-client";
       Fathom.load("GQAJEJLZ");
     </script>
-    <script>
-      window.addEventListener("vite:preloadError", (event) => {
-        event.preventDefault();
-        window.location.reload();
-      });
-    </script>
     <Font
       cssVariable="--font-sans"
       preload={[

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -46,6 +46,12 @@ const pageTitle = Astro.url.pathname === "/" ? title : `${title} · Namesake`;
       import * as Fathom from "fathom-client";
       Fathom.load("GQAJEJLZ");
     </script>
+    <script>
+      window.addEventListener("vite:preloadError", (event) => {
+        event.preventDefault();
+        window.location.reload();
+      });
+    </script>
     <Font
       cssVariable="--font-sans"
       preload={[

--- a/web/src/pages/_guides.spec.ts
+++ b/web/src/pages/_guides.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("guides", () => {
+  test("shows embedded form document names", async ({ page }) => {
+    await page.goto("/guides/ma/court-order");
+
+    await expect(
+      page
+        .getByText(
+          "This form helps you fill out name change documents, including:",
+        )
+        .first(),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Petition to Change Name of Adult (CJP-27)"),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Court Activity Record Request Form (CJP-34)"),
+    ).toBeVisible();
+  });
+});

--- a/web/src/pages/forms/[slug].astro
+++ b/web/src/pages/forms/[slug].astro
@@ -1,8 +1,8 @@
 ---
 import { type CollectionEntry, getCollection } from "astro:content";
+import FormContainer from "#components/forms/FormContainer/FormContainer.astro";
 import type { FormSlug } from "#constants/forms";
 import BaseLayout from "#layouts/BaseLayout.astro";
-import { FormContainer } from "../../components/forms/FormContainer";
 import { getFormConfig } from "../../lib/forms/getFormConfig";
 
 export async function getStaticPaths() {
@@ -29,5 +29,5 @@ if (!config) return Astro.redirect("/404");
     alt: config.title,
   }}
 >
-  <FormContainer client:load slug={form.id as FormSlug} />
+  <FormContainer slug={form.id as FormSlug} inline={false} />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- preload PDF metadata through an Astro wrapper for guide-embedded form islands
- seed the React form container with preloaded PDF metadata while preserving the existing client fallback
- add unit and guide-route regression coverage for embedded document names

Fixes #712

## Validation
- `corepack pnpm --filter @namesake/web test:once src/components/forms/FormContainer/FormContainer.test.tsx`
- `PATH="/tmp/corepack-shims:$PATH" pnpm --filter @namesake/web exec playwright test src/pages/_guides.spec.ts --project=chromium`
- `corepack pnpm --filter @namesake/web astro check`
- `corepack pnpm --filter @namesake/web build:only`
- `PATH="/tmp/corepack-shims:$PATH" pnpm check` (passes with an existing unrelated unused-parameter warning in `web/src/content/pdfs/ny/ucsnc1-name-change-and-or-sex-designation-change-petition-for-individual-adult/index.ts`)

Note: local validation ran on Node v22.23.1, while the repo declares Node >=24.0.0; commands emitted engine warnings.