### PR TITLE
Fix supportmap click navigation

### DIFF
--- a/web/src/components/SupportMap.astro
+++ b/web/src/components/SupportMap.astro
@@ -286,9 +286,6 @@ function getFillForSupportLevel(supportLevel: string): string {
       const hoveredState = select(this as SVGPathElement);
       hoveredState.attr("data-hovered", "true");
 
-      const node = hoveredState.node() as SVGPathElement;
-      if (node && node.parentNode) node.parentNode.appendChild(node);
-
       tooltip
         .attr("data-visible", "true")
         .html(`<strong>${stateName}</strong><br/>${supportText}`);

--- a/web/src/components/forms/FormCompleteStep/FormCompleteStep.test.tsx
+++ b/web/src/components/forms/FormCompleteStep/FormCompleteStep.test.tsx
@@ -39,6 +39,18 @@ describe("FormCompleteStep", () => {
       expect(screen.getByText(/Massachusetts Court Order/)).toBeInTheDocument();
     });
 
+    it("renders a form-specific completion message", () => {
+      render(
+        <FormCompleteStep
+          {...defaultProps}
+          completionMessage="Remember to sign the application."
+        />,
+      );
+      expect(
+        screen.getByText("Remember to sign the application."),
+      ).toBeInTheDocument();
+    });
+
     it("renders a redownload button", () => {
       render(<FormCompleteStep {...defaultProps} />);
       expect(

--- a/web/src/components/forms/FormCompleteStep/FormCompleteStep.tsx
+++ b/web/src/components/forms/FormCompleteStep/FormCompleteStep.tsx
@@ -1,6 +1,7 @@
 import { RiDownloadLine, RiRestartLine } from "@remixicon/react";
 import { useEffect, useState } from "react";
 import { clearFormProgress } from "#db/database";
+import { Banner } from "../../common/Banner";
 import { Button } from "../../common/Button";
 import { Heading } from "../../common/Content/Content";
 import { DeleteFormDataModal } from "../DeleteFormDataModal";
@@ -12,6 +13,7 @@ export interface FormCompleteStepProps {
   slug: FormSlug;
   title: string;
   onRedownload: (e: React.SubmitEvent<HTMLFormElement>) => void | Promise<void>;
+  completionMessage?: string;
   inline?: boolean;
   headingLevel?: 1 | 2 | 3;
 }
@@ -20,6 +22,7 @@ export function FormCompleteStep({
   slug,
   title,
   onRedownload,
+  completionMessage,
   inline = false,
   headingLevel = 1,
 }: FormCompleteStepProps) {
@@ -63,6 +66,7 @@ export function FormCompleteStep({
         </p>
       </header>
       <div className="form-complete-step-content">
+        {completionMessage && <Banner>{completionMessage}</Banner>}
         <FormFeedback slug={slug} />
         <DeleteFormDataModal />
         <div className="form-complete-actions">

--- a/web/src/components/forms/FormContainer/FormContainer.tsx
+++ b/web/src/components/forms/FormContainer/FormContainer.tsx
@@ -170,6 +170,7 @@ export function FormContainer({
             title={title}
             slug={slug}
             onRedownload={onSubmit}
+            completionMessage={config.completionMessage}
             inline={inline}
             headingLevel={inline ? 2 : 1}
           />
@@ -184,6 +185,7 @@ export function FormContainer({
     pdfs,
     title,
     description,
+    config.completionMessage,
     children,
     slug,
     totalSteps,

--- a/web/src/components/forms/RadioGroupField/RadioGroupField.test.tsx
+++ b/web/src/components/forms/RadioGroupField/RadioGroupField.test.tsx
@@ -1,4 +1,6 @@
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
 import { describe, expect, it } from "vitest";
 import { renderWithFormProvider, screen } from "../test-utils";
 import { RadioGroupField } from "./RadioGroupField";
@@ -8,6 +10,23 @@ const mockOptions = [
   { label: "Option 2", value: "option2" },
   { label: "Option 3", value: "option3" },
 ];
+
+function FieldValue() {
+  const { getValues } = useFormContext();
+  const [value, setValue] = useState("");
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setValue(JSON.stringify(getValues("newGender")))}
+      >
+        Read field value
+      </button>
+      <output data-testid="field-value">{value}</output>
+    </>
+  );
+}
 
 describe("RadioGroupField", () => {
   it("renders radio group with correct label", () => {
@@ -38,6 +57,23 @@ describe("RadioGroupField", () => {
       const radioOption = screen.getByText(option.label);
       expect(radioOption).toBeInTheDocument();
     }
+  });
+
+  it("initializes an unanswered radio group with null", async () => {
+    const user = userEvent.setup();
+    renderWithFormProvider(
+      <>
+        <RadioGroupField
+          name="newGender"
+          label="Test Label"
+          options={mockOptions}
+        />
+        <FieldValue />
+      </>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Read field value" }));
+    expect(screen.getByTestId("field-value")).toHaveTextContent("null");
   });
 
   it("allows selecting a radio option", async () => {

--- a/web/src/components/forms/RadioGroupField/RadioGroupField.tsx
+++ b/web/src/components/forms/RadioGroupField/RadioGroupField.tsx
@@ -29,6 +29,7 @@ export function RadioGroupField({
   labelHidden,
   options,
   children,
+  defaultValue,
   includePreferNotToAnswer,
   ...props
 }: RadioGroupFieldProps) {
@@ -39,7 +40,9 @@ export function RadioGroupField({
       <Controller
         control={control}
         name={name}
-        defaultValue={[]}
+        // Array format removed from defaultValue. Now it will be null instead
+        // This pre-empts a typeerror if an empty array is passed to @libpdf/core
+        defaultValue={defaultValue ?? null}
         render={({ field, fieldState: { invalid, error } }) => (
           <RadioGroup
             {...field}

--- a/web/src/constants/fields.ts
+++ b/web/src/constants/fields.ts
@@ -690,6 +690,238 @@ export const FIELD_DEFS = [
     label: "Waive fees?",
     type: "boolean",
   },
+  {
+    // Specific to LIC100 in MA
+    name: "stateIdType",
+    label: "ID type",
+    type: "string",
+    options: {
+      realId: "REAL ID",
+      standardId: "Standard ID",
+    },
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "stateIdDocumentType",
+    label: "Document to issue",
+    type: "string",
+    options: {
+      learnersPermit: "Learner's permit",
+      driversLicense: "Driver's license",
+      massachusettsIdCard: "Massachusetts ID card",
+    },
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "driversLicenseClass",
+    label: "Permit or license class",
+    type: "string",
+    options: {
+      passenger: "Passenger (Class D)",
+      motorcycle: "Motorcycle (Class M)",
+      both: "Both (Class D/M)",
+    },
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "nameSuffix",
+    label: "Name suffix",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "currentMassachusettsCredentialNumber",
+    label: "Current Massachusetts credential number",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "shouldChangeAddress",
+    label: "Change address?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "shouldChangeDateOfBirth",
+    label: "Change date of birth?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "shouldChangeGenderMarker",
+    label: "Change gender marker?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "shouldChangeHeight",
+    label: "Change height?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "shouldChangeEyeColor",
+    label: "Change eye color?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "phoneType",
+    label: "Phone type",
+    type: "string",
+    options: { cell: "Cell", home: "Home", work: "Work" },
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "hasEmergencyContact",
+    label: "Include an emergency contact?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "emergencyContactEmail",
+    label: "Emergency contact email",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "emergencyContactName",
+    label: "Emergency contact name",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "emergencyContactPhoneType",
+    label: "Emergency contact phone type",
+    type: "string",
+    options: { cell: "Cell", home: "Home", work: "Work" },
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "emergencyContactPhoneNumber",
+    label: "Emergency contact phone number",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "eyeColor",
+    label: "Eye color",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "heightFeet",
+    label: "Height (feet)",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "heightInches",
+    label: "Height (inches)",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "isOrganDonor",
+    label: "Organ and tissue donor?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "isActiveDutyMilitary",
+    label: "Active-duty military member?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "isVeteran",
+    label: "Veteran?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "shouldAddVeteranDesignation",
+    label: "Add veteran designation?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "militaryBranch",
+    label: "Military branch",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "isUSCitizen",
+    label: "U.S. citizen?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "hasOtherJurisdictionCredential",
+    label: "Held a license in another jurisdiction in the past 10 years?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "otherCredentialJurisdiction",
+    label: "Other credential jurisdiction",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "otherCredentialClass",
+    label: "Other credential class",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "otherCredentialNumber",
+    label: "Other credential number",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "currentOtherCredentials",
+    label: "Other current licenses or permits",
+    type: "string",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "hasDrivingImpairment",
+    label: "Impairment that may affect safe driving?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "takesDrivingMedication",
+    label: "Medication that may affect safe driving?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "hasSuspendedLicense",
+    label: "License or driving right suspended or revoked?",
+    type: "boolean",
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "consentProviderType",
+    label: "Person giving consent",
+    type: "string",
+    options: {
+      parent: "Parent",
+      legalGuardian: "Legal guardian",
+      departmentOfChildrenAndFamilies: "Department of Children and Families",
+      boardingSchoolHeadmaster: "Boarding school headmaster",
+    },
+  },
+  {
+    // Specific to LIC100 in MA
+    name: "guardianAddress",
+    label: "Parent or guardian address",
+    type: "string",
+  },
 ] as const;
 
 export type FieldName = (typeof FIELD_DEFS)[number]["name"];

--- a/web/src/constants/forms.ts
+++ b/web/src/constants/forms.ts
@@ -11,6 +11,7 @@ export const FORM_SLUGS = [
   "court-order-ri",
   "social-security",
   "birth-certificate-affidavit-ma",
+  "state-id-ma",
 ] as const;
 
 export type FormSlug = (typeof FORM_SLUGS)[number];
@@ -75,6 +76,8 @@ export interface FormConfig {
   pdfs: readonly FormPdfConfig[];
   /** Title for the downloaded PDF package */
   downloadTitle: string;
+  /** Optional message shown after the form has downloaded */
+  completionMessage?: string;
   /**
    * Instructions shown on the cover page of the downloaded packet.
    * Plain string = always included.

--- a/web/src/constants/pdf.ts
+++ b/web/src/constants/pdf.ts
@@ -1,7 +1,7 @@
 import type { FormData } from "./fields";
 import type { JurisdictionId } from "./jurisdictions";
 
-/** Matches libpdf's FieldValue, plus undefined for omitted fields. */
+/** Matches libpdf's FieldValue, plus undefined for omitted fields. Arrays are list-box values. */
 export type PDFFieldValue = string | boolean | string[] | null | undefined;
 
 /** Valid field types that can appear in a generated pdfSchema. */
@@ -12,6 +12,7 @@ export const PDF_IDS = [
   "cjp25-petition-to-change-name-of-minor",
   "cjp27-petition-to-change-name-of-adult",
   "cjp34-cori-and-wms-release-request",
+  "lic100-drivers-license-learners-permit-or-id-card",
   "ss5-application-for-social-security-card",
   "pc8.1-change-of-name",
   "background-check-authorization-of-release",
@@ -69,6 +70,9 @@ export interface PDFDefinition<TPdfFieldName extends string = string> {
    * ```
    */
   resolver: PDFResolver<TPdfFieldName>;
+
+  /** Draw selected checkbox and radio values into page content before merging. */
+  drawFormControlValues?: boolean;
 }
 
 export type PDFResolver<

--- a/web/src/content/forms/state-id-ma/e2e.spec.ts
+++ b/web/src/content/forms/state-id-ma/e2e.spec.ts
@@ -1,0 +1,189 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test("Massachusetts State ID", async ({ page }, testInfo) => {
+  // The full workflow includes guide rendering, accessibility checks, and a PDF download.
+  test.setTimeout(60_000);
+
+  await page.goto("/guides/ma/state-id");
+  await expect(
+    page.getByRole("heading", { name: "Fill out forms" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "State ID: Massachusetts" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Driver's license/ID amendment fee"),
+  ).toBeVisible();
+
+  await page.goto("/forms/state-id-ma");
+
+  expect(page).toHaveTitle(/State ID: Massachusetts/);
+  await expect(
+    page.getByRole("heading", { name: "State ID: Massachusetts" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "Driver's License, Learner's Permit, or ID Card Application (LIC100)",
+    ),
+  ).toBeVisible();
+  const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+  await testInfo.attach("accessibility-scan-results", {
+    body: JSON.stringify(accessibilityScanResults, null, 2),
+    contentType: "application/json",
+  });
+  expect(accessibilityScanResults.violations).toHaveLength(0);
+
+  await page.getByRole("button", { name: "Start" }).click();
+
+  await expect(
+    page.getByText(
+      "A Massachusetts REAL ID has a star in the top-right corner.",
+    ),
+  ).toBeVisible();
+  await page.getByText("Standard ID", { exact: true }).click();
+  await expect(
+    page.getByText(
+      "A Standard ID does not have a star and is not acceptable as federal identification.",
+    ),
+  ).toBeVisible();
+  await page.getByText("Driver's license", { exact: true }).click();
+  await page.getByText("Passenger (Class D)", { exact: true }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page.getByRole("textbox", { name: "First name" }).fill("Marsha");
+  await page.getByRole("textbox", { name: "Middle name" }).fill("P");
+  await page
+    .getByRole("textbox", { name: "Last or family name" })
+    .fill("Johnson");
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page.getByRole("textbox", { name: "First name" }).fill("Old");
+  await page.getByRole("textbox", { name: "Middle name" }).fill("M");
+  await page.getByRole("textbox", { name: "Last or family name" }).fill("Name");
+  await page
+    .getByRole("textbox", { name: "Current Massachusetts credential number" })
+    .fill("S12345678");
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page
+    .getByRole("spinbutton", { name: "month, Date of birth" })
+    .pressSequentially("01011990");
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page.getByText("Gender marker", { exact: true }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page
+    .getByText("I am currently unhoused or without permanent housing")
+    .click();
+  await expect(
+    page.getByText(
+      "If you are staying at a shelter or hospital, enter the facility's address below.",
+      { exact: false },
+    ),
+  ).toBeVisible();
+  await page
+    .getByRole("searchbox", { name: "Street address" })
+    .fill("123 Main St");
+  await page.getByRole("textbox", { name: "City" }).fill("Boston");
+  const stateCombobox = page.getByRole("combobox", { name: "State" });
+  await stateCombobox.click();
+  await stateCombobox.fill("mass");
+  await stateCombobox.press("ArrowDown");
+  await stateCombobox.press("Enter");
+  await expect(stateCombobox).toHaveValue("Massachusetts");
+  await page.getByRole("textbox", { name: "ZIP" }).fill("02108");
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page
+    .getByRole("textbox", { name: "Email address" })
+    .fill("test@example.com");
+  await page.getByRole("textbox", { name: "Phone number" }).fill("6175550123");
+  await page.getByText("Cell", { exact: true }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page.getByText("No", { exact: true }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await expect(
+    page.getByText("Nonbinary, gender-fluid, or gender-nonconforming people"),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Intersex people", { exact: false }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "Massachusetts does not require medical proof or documentation to choose or switch to an X designation on a driver's license or state ID.",
+    ),
+  ).toBeVisible();
+  // Leave gender and eye color unanswered to cover optional radio values in the PDF.
+  await page.getByRole("textbox", { name: "Feet" }).fill("5");
+  await page.getByRole("textbox", { name: "Inches" }).fill("8");
+  await page
+    .getByRole("radiogroup", {
+      name: "Register me, or keep me registered, as an organ and tissue donor",
+    })
+    .getByText("Yes", { exact: true })
+    .click();
+  await expect(
+    page.getByText(
+      "If you are already registered as an organ and tissue donor, select Yes to remain registered.",
+    ),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page.getByText("Yes", { exact: true }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await expect(
+    page.getByText(
+      "An out-of-state driver's license or ID card may be canceled when your Massachusetts driver's license or ID card is issued.",
+    ),
+  ).toBeVisible();
+  await page.getByText("No", { exact: true }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  for (const question of [
+    "Do you have a cognitive, neurologic, physical, or other impairment that may affect your ability to operate a motor vehicle safely?",
+    "Are you taking any medication that may affect your ability to safely operate a motor vehicle?",
+    "Is your license or right to operate suspended, revoked, canceled, withdrawn, or disqualified here or in another jurisdiction?",
+  ]) {
+    await page
+      .getByRole("radiogroup", { name: question })
+      .getByText("No", { exact: true })
+      .click();
+  }
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Review your information" }),
+  ).toBeVisible();
+  await expect(page.getByText("New last name: Johnson")).toBeVisible();
+  await expect(page.getByText("Currently unhoused? Yes")).toBeVisible();
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Finish and Download" }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe(
+    "Massachusetts State ID Application.pdf",
+  );
+  const downloadPath = await download.path();
+  expect(downloadPath).not.toBeNull();
+  if (downloadPath) {
+    await testInfo.attach("filled-state-id-application", {
+      path: downloadPath,
+      contentType: "application/pdf",
+    });
+  }
+  await expect(
+    page.getByRole("heading", { name: "Form complete!" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "Remember to print, sign, and date your application. The application is not complete without your signature.",
+    ),
+  ).toBeVisible();
+});

--- a/web/src/content/forms/state-id-ma/index.ts
+++ b/web/src/content/forms/state-id-ma/index.ts
@@ -1,0 +1,65 @@
+import { defineForm } from "#lib/forms/defineForm";
+import { addressStep } from "./steps/AddressStep";
+import { citizenshipStep } from "./steps/CitizenshipStep";
+import { contactInfoStep } from "./steps/ContactInfoStep";
+import { credentialHistoryStep } from "./steps/CredentialHistoryStep";
+import { credentialStep } from "./steps/CredentialStep";
+import { currentCredentialStep } from "./steps/CurrentCredentialStep";
+import { dateOfBirthStep } from "./steps/DateOfBirthStep";
+import { demographicsStep } from "./steps/DemographicsStep";
+import { drivingSafetyStep } from "./steps/DrivingSafetyStep";
+import { emergencyContactStep } from "./steps/EmergencyContactStep";
+import { guardianConsentStep } from "./steps/GuardianConsentStep";
+import { militaryStep } from "./steps/MilitaryStep";
+import { newNameStep } from "./steps/NewNameStep";
+import { otherChangesStep } from "./steps/OtherChangesStep";
+
+export default defineForm({
+  title: "State ID: Massachusetts",
+  description:
+    "Update the name and other information on your Massachusetts driver's license, learner's permit, or ID card.",
+  jurisdiction: "ma",
+  category: "state-id",
+  costs: [
+    {
+      title: "Driver's license/ID amendment fee",
+      amount: 25,
+      required: "required",
+    },
+  ],
+  steps: [
+    credentialStep,
+    newNameStep,
+    currentCredentialStep,
+    dateOfBirthStep,
+    otherChangesStep,
+    addressStep,
+    contactInfoStep,
+    emergencyContactStep,
+    demographicsStep,
+    militaryStep,
+    citizenshipStep,
+    credentialHistoryStep,
+    drivingSafetyStep,
+    guardianConsentStep,
+  ],
+  pdfs: [{ pdfId: "lic100-drivers-license-learners-permit-or-id-card" }],
+  downloadTitle: "Massachusetts State ID Application",
+  completionMessage:
+    "Remember to print, sign, and date your application. The application is not complete without your signature.",
+  instructions: [
+    "Review the application carefully and complete any fields Namesake left blank.",
+    "Enter your Social Security number in section B7. For your privacy, Namesake never asks for it.",
+    "If you do not have a Social Security number, complete section B8 and bring the required supporting documents.",
+    "Sign and date the application after printing it.",
+    {
+      text: "The person giving consent must sign section H4. If they are not a parent, they must also provide proof of their authority.",
+      when: (data) => guardianConsentStep.when?.(data) === true,
+    },
+    {
+      text: "Because you selected REAL ID, bring an acceptable document proving your legal name change if your new name does not match your lawful-presence documents.",
+      when: (data) => data.stateIdType === "realId",
+    },
+    "Bring the application, your current credential, your updated Social Security card, and all required identity and residency documents to your RMV appointment.",
+  ],
+});

--- a/web/src/content/forms/state-id-ma/steps/AddressStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/AddressStep.tsx
@@ -1,0 +1,71 @@
+import { useFormContext } from "react-hook-form";
+import { Banner } from "#components/common/Banner";
+import { AddressField } from "#components/forms/AddressField";
+import { CheckboxField } from "#components/forms/CheckboxField";
+import {
+  FormStep,
+  FormSubsection,
+  useFieldVisible,
+} from "#components/forms/FormStep";
+import { defineStep } from "#lib/forms/defineStep";
+
+const whenMailing = (data: Record<string, unknown>) =>
+  data.isMailingAddressDifferentFromResidence === true;
+
+export const addressStep = defineStep({
+  id: "address",
+  title: "What is your residential address?",
+  description: "Enter the address where you currently live.",
+  fields: [
+    "isCurrentlyUnhoused",
+    "residenceStreetAddress",
+    "residenceStreetAddress2",
+    "residenceCity",
+    "residenceState",
+    "residenceZipCode",
+    "isMailingAddressDifferentFromResidence",
+    {
+      ids: [
+        "mailingStreetAddress",
+        "mailingStreetAddress2",
+        "mailingCity",
+        "mailingState",
+        "mailingZipCode",
+      ],
+      when: whenMailing,
+    },
+  ],
+  component: ({ stepConfig }) => {
+    const { watch } = useFormContext();
+    const isCurrentlyUnhoused = watch("isCurrentlyUnhoused") === true;
+    const mailingVisible = useFieldVisible(stepConfig, "mailingStreetAddress");
+
+    return (
+      <FormStep stepConfig={stepConfig}>
+        <CheckboxField
+          name="isCurrentlyUnhoused"
+          label="I am currently unhoused or without permanent housing"
+        />
+        {isCurrentlyUnhoused && (
+          <Banner variant="info">
+            If you are staying at a shelter or hospital, enter the facility's
+            address below. For proof of residency, bring an original letter from
+            the facility that includes your full name, date of birth, admission
+            date, and says you need an ID to obtain housing.
+          </Banner>
+        )}
+        <AddressField type="residence" includeAddress2 />
+        <CheckboxField
+          name="isMailingAddressDifferentFromResidence"
+          label="I use a different mailing address"
+        />
+        <FormSubsection
+          title="What is your mailing address?"
+          isVisible={mailingVisible}
+        >
+          <AddressField type="mailing" includeAddress2 />
+        </FormSubsection>
+      </FormStep>
+    );
+  },
+});

--- a/web/src/content/forms/state-id-ma/steps/CitizenshipStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/CitizenshipStep.tsx
@@ -1,0 +1,16 @@
+import { FormStep } from "#components/forms/FormStep";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#lib/forms/defineStep";
+
+export const citizenshipStep = defineStep({
+  id: "citizenship",
+  title: "Are you a citizen of the United States?",
+  description:
+    "The RMV uses this answer for voter registration. It does not determine whether you can receive a license or ID.",
+  fields: ["isUSCitizen"],
+  component: ({ stepConfig }) => (
+    <FormStep stepConfig={stepConfig}>
+      <YesNoField name="isUSCitizen" label="U.S. citizen?" labelHidden />
+    </FormStep>
+  ),
+});

--- a/web/src/content/forms/state-id-ma/steps/ContactInfoStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/ContactInfoStep.tsx
@@ -1,0 +1,28 @@
+import { EmailField } from "#components/forms/EmailField";
+import { FormStep } from "#components/forms/FormStep";
+import { PhoneField } from "#components/forms/PhoneField";
+import { RadioGroupField } from "#components/forms/RadioGroupField";
+import { defineStep } from "#lib/forms/defineStep";
+
+export const contactInfoStep = defineStep({
+  id: "contact-info",
+  title: "What is your contact information?",
+  description:
+    "The Registry of Motor Vehicles will not provide your email or phone number to the public.",
+  fields: ["email", "phoneType", "phoneNumber"],
+  component: ({ stepConfig }) => (
+    <FormStep stepConfig={stepConfig}>
+      <EmailField name="email" />
+      <RadioGroupField
+        name="phoneType"
+        label="Phone type"
+        options={[
+          { label: "Cell", value: "cell" },
+          { label: "Home", value: "home" },
+          { label: "Work", value: "work" },
+        ]}
+      />
+      <PhoneField name="phoneNumber" />
+    </FormStep>
+  ),
+});

--- a/web/src/content/forms/state-id-ma/steps/CredentialHistoryStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/CredentialHistoryStep.tsx
@@ -1,0 +1,77 @@
+import { Banner } from "#components/common/Banner";
+import {
+  FormStep,
+  FormSubsection,
+  useFieldVisible,
+} from "#components/forms/FormStep";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#lib/forms/defineStep";
+
+const whenOtherCredential = (data: Record<string, unknown>) =>
+  data.hasOtherJurisdictionCredential === true;
+
+export const credentialHistoryStep = defineStep({
+  id: "credential-history",
+  title: "Have you held a license somewhere else in the past 10 years?",
+  description:
+    "Include any class of license from another state, country, or jurisdiction.",
+  fields: [
+    "hasOtherJurisdictionCredential",
+    {
+      ids: [
+        "otherCredentialJurisdiction",
+        "otherCredentialClass",
+        "otherCredentialNumber",
+        "currentOtherCredentials",
+      ],
+      when: whenOtherCredential,
+    },
+  ],
+  component: ({ stepConfig }) => {
+    const detailsVisible = useFieldVisible(
+      stepConfig,
+      "otherCredentialJurisdiction",
+    );
+
+    return (
+      <FormStep stepConfig={stepConfig}>
+        <YesNoField
+          name="hasOtherJurisdictionCredential"
+          label="Held a license in another jurisdiction?"
+          labelHidden
+        />
+        <FormSubsection
+          title="Tell us about the other credential"
+          isVisible={detailsVisible}
+        >
+          <ShortTextField
+            name="otherCredentialJurisdiction"
+            label="Country or state"
+            size={24}
+          />
+          <ShortTextField
+            name="otherCredentialClass"
+            label="Credential class"
+            size={18}
+          />
+          <ShortTextField
+            name="otherCredentialNumber"
+            label="Credential number"
+            size={24}
+          />
+          <ShortTextField
+            name="currentOtherCredentials"
+            label="List any other current license or permit"
+            description="Leave blank if you do not currently hold another license or permit."
+            size={36}
+          />
+        </FormSubsection>
+        <Banner variant="info">
+          An out-of-state driver's license or ID card may be canceled when your
+          Massachusetts driver's license or ID card is issued.
+        </Banner>
+      </FormStep>
+    );
+  },
+});

--- a/web/src/content/forms/state-id-ma/steps/CredentialStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/CredentialStep.tsx
@@ -1,0 +1,77 @@
+import {
+  FormStep,
+  FormSubsection,
+  useFieldVisible,
+} from "#components/forms/FormStep";
+import { RadioGroupField } from "#components/forms/RadioGroupField";
+import { defineStep } from "#lib/forms/defineStep";
+
+const whenLicenseOrPermit = (data: Record<string, unknown>) =>
+  data.stateIdDocumentType === "learnersPermit" ||
+  data.stateIdDocumentType === "driversLicense";
+
+export const credentialStep = defineStep({
+  id: "credential",
+  title: "What kind of Massachusetts credential are you updating?",
+  fields: [
+    "stateIdType",
+    "stateIdDocumentType",
+    { id: "driversLicenseClass", when: whenLicenseOrPermit },
+  ],
+  component: ({ stepConfig }) => {
+    const licenseClassVisible = useFieldVisible(
+      stepConfig,
+      "driversLicenseClass",
+    );
+
+    return (
+      <FormStep stepConfig={stepConfig}>
+        <RadioGroupField
+          name="stateIdType"
+          label="ID type"
+          options={[
+            {
+              label: "REAL ID",
+              value: "realId",
+              description:
+                "A Massachusetts REAL ID has a star in the top-right corner.",
+            },
+            {
+              label: "Standard ID",
+              value: "standardId",
+              description:
+                "A Standard ID does not have a star and is not acceptable as federal identification.",
+            },
+          ]}
+        />
+        <RadioGroupField
+          name="stateIdDocumentType"
+          label="Document to issue"
+          options={[
+            { label: "Learner's permit", value: "learnersPermit" },
+            { label: "Driver's license", value: "driversLicense" },
+            {
+              label: "Massachusetts ID card",
+              value: "massachusettsIdCard",
+            },
+          ]}
+        />
+        <FormSubsection
+          title="What class is your permit or license?"
+          isVisible={licenseClassVisible}
+        >
+          <RadioGroupField
+            name="driversLicenseClass"
+            label="Permit or license class"
+            labelHidden
+            options={[
+              { label: "Passenger (Class D)", value: "passenger" },
+              { label: "Motorcycle (Class M)", value: "motorcycle" },
+              { label: "Both (Class D/M)", value: "both" },
+            ]}
+          />
+        </FormSubsection>
+      </FormStep>
+    );
+  },
+});

--- a/web/src/content/forms/state-id-ma/steps/CurrentCredentialStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/CurrentCredentialStep.tsx
@@ -1,0 +1,27 @@
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { defineStep } from "#lib/forms/defineStep";
+
+export const currentCredentialStep = defineStep({
+  id: "current-credential",
+  title: "What appears on your current Massachusetts credential?",
+  description:
+    "Enter your current name and credential number so the RMV can find your record.",
+  fields: [
+    "oldFirstName",
+    "oldMiddleName",
+    "oldLastName",
+    "currentMassachusettsCredentialNumber",
+  ],
+  component: ({ stepConfig }) => (
+    <FormStep stepConfig={stepConfig}>
+      <NameField type="oldName" />
+      <ShortTextField
+        name="currentMassachusettsCredentialNumber"
+        label="Current Massachusetts credential number"
+        size={24}
+      />
+    </FormStep>
+  ),
+});

--- a/web/src/content/forms/state-id-ma/steps/DateOfBirthStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/DateOfBirthStep.tsx
@@ -1,0 +1,14 @@
+import { FormStep } from "#components/forms/FormStep";
+import { MemorableDateField } from "#components/forms/MemorableDateField";
+import { defineStep } from "#lib/forms/defineStep";
+
+export const dateOfBirthStep = defineStep({
+  id: "date-of-birth",
+  title: "What is your date of birth?",
+  fields: ["dateOfBirth"],
+  component: ({ stepConfig }) => (
+    <FormStep stepConfig={stepConfig}>
+      <MemorableDateField label="Date of birth" name="dateOfBirth" />
+    </FormStep>
+  ),
+});

--- a/web/src/content/forms/state-id-ma/steps/DemographicsStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/DemographicsStep.tsx
@@ -1,0 +1,89 @@
+import { Banner } from "#components/common/Banner";
+import { FormStep, FormSubsection } from "#components/forms/FormStep";
+import { NumberField } from "#components/forms/NumberField";
+import { RadioGroupField } from "#components/forms/RadioGroupField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#lib/forms/defineStep";
+
+export const demographicsStep = defineStep({
+  id: "demographics",
+  title: "What information should appear on your ID?",
+  fields: [
+    "newGender",
+    "eyeColor",
+    "heightFeet",
+    "heightInches",
+    "isOrganDonor",
+  ],
+  component: ({ stepConfig }) => (
+    <FormStep stepConfig={stepConfig}>
+      <RadioGroupField
+        name="newGender"
+        label="Gender marker"
+        options={[
+          { label: "M", value: "Male" },
+          { label: "F", value: "Female" },
+          { label: "X", value: "X" },
+        ]}
+      />
+      <Banner variant="info">
+        <p>The X designation may be used by:</p>
+        <ul>
+          <li>
+            <strong>
+              Nonbinary, gender-fluid, or gender-nonconforming people
+            </strong>{" "}
+            whose gender identity is not strictly male or female
+          </li>
+          <li>
+            <strong>Intersex people</strong> whose sex characteristics do not
+            fit typical binary definitions
+          </li>
+          <li>
+            <strong>Anyone seeking privacy</strong>
+          </li>
+        </ul>
+        <p>
+          Massachusetts does not require medical proof or documentation to
+          choose or switch to an X designation on a driver's license or state
+          ID.
+        </p>
+      </Banner>
+      <RadioGroupField
+        name="eyeColor"
+        label="Eye color"
+        options={[
+          { label: "Black", value: "Black" },
+          { label: "Brown", value: "Brown" },
+          { label: "Gray", value: "Gray" },
+          { label: "Hazel", value: "Hazel" },
+          { label: "Pink", value: "Pink" },
+          { label: "Blue", value: "Blue" },
+          { label: "Dichromatic", value: "Dichromatic" },
+          { label: "Green", value: "Green" },
+          { label: "Maroon", value: "Maroon" },
+          { label: "Unknown", value: "Unknown" },
+        ]}
+      />
+      <FormSubsection title="Height">
+        <NumberField name="heightFeet" label="Feet" minValue={1} maxValue={8} />
+        <NumberField
+          name="heightInches"
+          label="Inches"
+          minValue={0}
+          maxValue={11}
+        />
+      </FormSubsection>
+      <YesNoField
+        name="isOrganDonor"
+        label="Register me, or keep me registered, as an organ and tissue donor"
+        yesLabel="Yes"
+        noLabel="No"
+      />
+      <Banner variant="info">
+        If you are already registered as an organ and tissue donor, select Yes
+        to remain registered.
+      </Banner>
+    </FormStep>
+  ),
+});

--- a/web/src/content/forms/state-id-ma/steps/DrivingSafetyStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/DrivingSafetyStep.tsx
@@ -1,0 +1,34 @@
+import { FormStep } from "#components/forms/FormStep";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#lib/forms/defineStep";
+
+export const drivingSafetyStep = defineStep({
+  id: "driving-safety",
+  title: "Answer the RMV's driving safety questions",
+  description:
+    "These questions apply only to driver's license and learner's permit applicants.",
+  fields: [
+    "hasDrivingImpairment",
+    "takesDrivingMedication",
+    "hasSuspendedLicense",
+  ],
+  when: (data) =>
+    data.stateIdDocumentType === "learnersPermit" ||
+    data.stateIdDocumentType === "driversLicense",
+  component: ({ stepConfig }) => (
+    <FormStep stepConfig={stepConfig}>
+      <YesNoField
+        name="hasDrivingImpairment"
+        label="Do you have a cognitive, neurologic, physical, or other impairment that may affect your ability to operate a motor vehicle safely?"
+      />
+      <YesNoField
+        name="takesDrivingMedication"
+        label="Are you taking any medication that may affect your ability to safely operate a motor vehicle?"
+      />
+      <YesNoField
+        name="hasSuspendedLicense"
+        label="Is your license or right to operate suspended, revoked, canceled, withdrawn, or disqualified here or in another jurisdiction?"
+      />
+    </FormStep>
+  ),
+});

--- a/web/src/content/forms/state-id-ma/steps/EmergencyContactStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/EmergencyContactStep.tsx
@@ -1,0 +1,66 @@
+import { EmailField } from "#components/forms/EmailField";
+import {
+  FormStep,
+  FormSubsection,
+  useFieldVisible,
+} from "#components/forms/FormStep";
+import { PhoneField } from "#components/forms/PhoneField";
+import { RadioGroupField } from "#components/forms/RadioGroupField";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { YesNoField } from "#components/forms/YesNoField";
+import { defineStep } from "#lib/forms/defineStep";
+
+const whenEmergencyContact = (data: Record<string, unknown>) =>
+  data.hasEmergencyContact === true;
+
+export const emergencyContactStep = defineStep({
+  id: "emergency-contact",
+  title: "Would you like to include an emergency contact?",
+  description: "This section of the RMV application is optional.",
+  fields: [
+    "hasEmergencyContact",
+    {
+      ids: [
+        "emergencyContactName",
+        "emergencyContactEmail",
+        "emergencyContactPhoneType",
+        "emergencyContactPhoneNumber",
+      ],
+      when: whenEmergencyContact,
+    },
+  ],
+  component: ({ stepConfig }) => {
+    const detailsVisible = useFieldVisible(stepConfig, "emergencyContactName");
+
+    return (
+      <FormStep stepConfig={stepConfig}>
+        <YesNoField
+          name="hasEmergencyContact"
+          label="Include an emergency contact?"
+          labelHidden
+        />
+        <FormSubsection
+          title="Emergency contact information"
+          isVisible={detailsVisible}
+        >
+          <ShortTextField
+            name="emergencyContactName"
+            label="Full name"
+            size={30}
+          />
+          <EmailField name="emergencyContactEmail" label="Email address" />
+          <RadioGroupField
+            name="emergencyContactPhoneType"
+            label="Phone type"
+            options={[
+              { label: "Cell", value: "cell" },
+              { label: "Home", value: "home" },
+              { label: "Work", value: "work" },
+            ]}
+          />
+          <PhoneField name="emergencyContactPhoneNumber" label="Phone number" />
+        </FormSubsection>
+      </FormStep>
+    );
+  },
+});

--- a/web/src/content/forms/state-id-ma/steps/GuardianConsentStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/GuardianConsentStep.tsx
@@ -1,0 +1,53 @@
+import { Banner } from "#components/common/Banner";
+import { FormStep } from "#components/forms/FormStep";
+import { RadioGroupField } from "#components/forms/RadioGroupField";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { defineStep } from "#lib/forms/defineStep";
+import { deriveCurrentAge } from "#lib/utils/deriveCurrentAge";
+
+export const guardianConsentStep = defineStep({
+  id: "guardian-consent",
+  title: "Who will give consent for your application?",
+  description:
+    "Because you are under 18, the person giving consent must sign the printed application.",
+  fields: ["consentProviderType", "guardianFullName", "guardianAddress"],
+  when: (data) => {
+    // deriveCurrentAge returns -1 until a valid date of birth is available.
+    const age = deriveCurrentAge(data.dateOfBirth);
+    return age >= 0 && age < 18;
+  },
+  component: ({ stepConfig }) => (
+    <FormStep stepConfig={stepConfig}>
+      <RadioGroupField
+        name="consentProviderType"
+        label="Person giving consent"
+        options={[
+          { label: "Parent", value: "parent" },
+          { label: "Legal guardian", value: "legalGuardian" },
+          {
+            label: "Department of Children and Families",
+            value: "departmentOfChildrenAndFamilies",
+          },
+          {
+            label: "Boarding school headmaster",
+            value: "boardingSchoolHeadmaster",
+          },
+        ]}
+      />
+      <ShortTextField
+        name="guardianFullName"
+        label="Parent or guardian's full name"
+        size={30}
+      />
+      <ShortTextField
+        name="guardianAddress"
+        label="Parent or guardian's full address"
+        size={40}
+      />
+      <Banner variant="info">
+        If the person giving consent is not your parent, they must show proper
+        documentation of their authority.
+      </Banner>
+    </FormStep>
+  ),
+});

--- a/web/src/content/forms/state-id-ma/steps/MilitaryStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/MilitaryStep.tsx
@@ -1,0 +1,56 @@
+import { CheckboxField } from "#components/forms/CheckboxField";
+import {
+  FormStep,
+  FormSubsection,
+  useFieldVisible,
+} from "#components/forms/FormStep";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { defineStep } from "#lib/forms/defineStep";
+
+const whenMilitary = (data: Record<string, unknown>) =>
+  data.isActiveDutyMilitary === true || data.isVeteran === true;
+
+const whenVeteran = (data: Record<string, unknown>) => data.isVeteran === true;
+
+export const militaryStep = defineStep({
+  id: "military-status",
+  title: "What is your military status?",
+  description:
+    "Leave both boxes unchecked if neither applies. Documentation is required for any military status you select.",
+  fields: [
+    "isActiveDutyMilitary",
+    "isVeteran",
+    { id: "shouldAddVeteranDesignation", when: whenVeteran },
+    { id: "militaryBranch", when: whenMilitary },
+  ],
+  component: ({ stepConfig }) => {
+    const veteranDesignationVisible = useFieldVisible(
+      stepConfig,
+      "shouldAddVeteranDesignation",
+    );
+    const militaryBranchVisible = useFieldVisible(stepConfig, "militaryBranch");
+
+    return (
+      <FormStep stepConfig={stepConfig}>
+        <CheckboxField
+          name="isActiveDutyMilitary"
+          label="I am an active-duty member"
+        />
+        <CheckboxField name="isVeteran" label="I am a veteran" />
+        <FormSubsection isVisible={veteranDesignationVisible}>
+          <CheckboxField
+            name="shouldAddVeteranDesignation"
+            label='Print the word "VETERAN" on my ID'
+          />
+        </FormSubsection>
+        <FormSubsection isVisible={militaryBranchVisible}>
+          <ShortTextField
+            name="militaryBranch"
+            label="Military branch"
+            size={24}
+          />
+        </FormSubsection>
+      </FormStep>
+    );
+  },
+});

--- a/web/src/content/forms/state-id-ma/steps/NewNameStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/NewNameStep.tsx
@@ -1,0 +1,23 @@
+import { FormStep } from "#components/forms/FormStep";
+import { NameField } from "#components/forms/NameField";
+import { ShortTextField } from "#components/forms/ShortTextField";
+import { defineStep } from "#lib/forms/defineStep";
+
+export const newNameStep = defineStep({
+  id: "new-name",
+  title: "What is your new legal name?",
+  description:
+    "Type your name exactly as it appears on your Social Security record.",
+  fields: ["newFirstName", "newMiddleName", "newLastName", "nameSuffix"],
+  component: ({ stepConfig }) => (
+    <FormStep stepConfig={stepConfig}>
+      <NameField type="newName" />
+      <ShortTextField
+        name="nameSuffix"
+        label="Suffix (optional)"
+        description="For example, Jr., Sr., II, or III."
+        size={12}
+      />
+    </FormStep>
+  ),
+});

--- a/web/src/content/forms/state-id-ma/steps/OtherChangesStep.tsx
+++ b/web/src/content/forms/state-id-ma/steps/OtherChangesStep.tsx
@@ -1,0 +1,26 @@
+import { CheckboxField } from "#components/forms/CheckboxField";
+import { FormStep } from "#components/forms/FormStep";
+import { defineStep } from "#lib/forms/defineStep";
+
+export const otherChangesStep = defineStep({
+  id: "other-changes",
+  title: "Besides your name, what else are you changing?",
+  description:
+    "Namesake will mark name change on your application. Check any other information the RMV should update.",
+  fields: [
+    "shouldChangeAddress",
+    "shouldChangeDateOfBirth",
+    "shouldChangeGenderMarker",
+    "shouldChangeHeight",
+    "shouldChangeEyeColor",
+  ],
+  component: ({ stepConfig }) => (
+    <FormStep stepConfig={stepConfig}>
+      <CheckboxField name="shouldChangeAddress" label="Address" />
+      <CheckboxField name="shouldChangeDateOfBirth" label="Date of birth" />
+      <CheckboxField name="shouldChangeGenderMarker" label="Gender marker" />
+      <CheckboxField name="shouldChangeHeight" label="Height" />
+      <CheckboxField name="shouldChangeEyeColor" label="Eye color" />
+    </FormStep>
+  ),
+});

--- a/web/src/content/guides/ma/state-id.mdx
+++ b/web/src/content/guides/ma/state-id.mdx
@@ -40,7 +40,7 @@ Name change requests must be completed at an RMV Service Center. You must [**sch
 
 ## Show up to your appointment
 
-<Costs costs={[{"title":"Massachusetts ID Card Fee","amount":25,"required":"required"}]} />
+<Costs costs={[{"title":"Driver's license/ID amendment fee","amount":25,"required":"required"}]} />
 
 Bring your completed application to your appointment. You'll need to bring your proof of name change as well as your new social security card. You may also need proof of residency, such as a recent bill or lease. A REAL ID requires two documents proving Massachusetts residency; a Standard ID requires one.
 

--- a/web/src/content/guides/ma/state-id.mdx
+++ b/web/src/content/guides/ma/state-id.mdx
@@ -6,6 +6,7 @@ category: state-id
 ---
 
 import Costs from "#components/Costs.astro"
+import { FormContainer } from "#components/forms/FormContainer/index.ts"
 
 ## Get prepared
 
@@ -13,9 +14,9 @@ To update your ID, you will need a completed **court order** certifying your nam
 
 ## Fill out forms
 
-Fill out required documents for the RMV.
+Namesake will walk you through the questions required to fill out the RMV application. Once finished, a PDF will be downloaded for you to review and sign.
 
-[Complete application](https://www.mass.gov/doc/license-and-id-application-0/download)
+<FormContainer client:load slug="state-id-ma" inline />
 
 <details>
 <summary>Can I update my ID or license online?</summary>
@@ -41,7 +42,7 @@ Name change requests must be completed at an RMV Service Center. You must [**sch
 
 <Costs costs={[{"title":"Massachusetts ID Card Fee","amount":25,"required":"required"}]} />
 
-Bring your completed application to your appointment. You'll need to bring your proof of name change as well as your new social security card. You may also need proof of residency, such as a recent bill or lease.
+Bring your completed application to your appointment. You'll need to bring your proof of name change as well as your new social security card. You may also need proof of residency, such as a recent bill or lease. A REAL ID requires two documents proving Massachusetts residency; a Standard ID requires one.
 
 The RMV will take your photo and get your new signature.
 

--- a/web/src/content/pdfs/ma/lic100-drivers-license-learners-permit-or-id-card/index.test.ts
+++ b/web/src/content/pdfs/ma/lic100-drivers-license-learners-permit-or-id-card/index.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { FormData } from "#constants/fields";
+import { expectPdfFieldsMatch } from "#lib/pdfs/expectPdfFieldsMatch";
+import { fillPdf } from "#lib/pdfs/fillPdf";
+import licenseAndIdApplication from ".";
+
+describe("LIC100 Driver's License, Learner's Permit, or ID Card Application", () => {
+  const testData: Partial<FormData> = {
+    stateIdType: "realId",
+    stateIdDocumentType: "driversLicense",
+    driversLicenseClass: "passenger",
+    newFirstName: "Marsha",
+    newMiddleName: "P",
+    newLastName: "Johnson",
+    nameSuffix: "Jr.",
+    oldFirstName: "Old",
+    oldMiddleName: "M",
+    oldLastName: "Name",
+    currentMassachusettsCredentialNumber: "S12345678",
+    dateOfBirth: "1990-01-01",
+    shouldChangeAddress: false,
+    shouldChangeDateOfBirth: false,
+    shouldChangeGenderMarker: true,
+    shouldChangeHeight: false,
+    shouldChangeEyeColor: false,
+    residenceStreetAddress: "123 Main St",
+    residenceStreetAddress2: "Apt 4",
+    residenceCity: "Boston",
+    residenceState: "MA",
+    residenceZipCode: "02108",
+    isMailingAddressDifferentFromResidence: true,
+    mailingStreetAddress: "456 Post St",
+    mailingStreetAddress2: "Unit 2",
+    mailingCity: "Cambridge",
+    mailingState: "MA",
+    mailingZipCode: "02139",
+    email: "test@example.com",
+    phoneType: "cell",
+    phoneNumber: "+1 (617) 555-0123",
+    hasEmergencyContact: true,
+    emergencyContactEmail: "contact@example.com",
+    emergencyContactName: "Sylvia Rivera",
+    emergencyContactPhoneType: "home",
+    emergencyContactPhoneNumber: "+1 (617) 555-0456",
+    newGender: "X",
+    eyeColor: "Brown",
+    heightFeet: "5",
+    heightInches: "8",
+    isOrganDonor: true,
+    isActiveDutyMilitary: false,
+    isVeteran: true,
+    shouldAddVeteranDesignation: true,
+    militaryBranch: "Army",
+    isUSCitizen: true,
+    hasOtherJurisdictionCredential: true,
+    otherCredentialJurisdiction: "Rhode Island",
+    otherCredentialClass: "D",
+    otherCredentialNumber: "1234567",
+    currentOtherCredentials: "Rhode Island ID 7654321",
+    hasDrivingImpairment: false,
+    takesDrivingMedication: false,
+    hasSuspendedLicense: false,
+    consentProviderType: "parent",
+    guardianFullName: "Parent Name",
+    guardianAddress: "789 Family St, Boston, MA 02108",
+  };
+
+  it("maps all fields correctly to the PDF", async () => {
+    await expectPdfFieldsMatch(licenseAndIdApplication, testData);
+  });
+
+  it("leaves unanswered radio fields blank", async () => {
+    const incompleteData: Partial<FormData> = {
+      newGender: [] as unknown as FormData["newGender"],
+      eyeColor: [] as unknown as FormData["eyeColor"],
+    };
+
+    const fields = licenseAndIdApplication.resolver(incompleteData);
+    expect(fields.Gender).toBeUndefined();
+    expect(fields["Eye Color"]).toBeUndefined();
+    await expect(
+      fillPdf({ pdf: licenseAndIdApplication, userData: incompleteData }),
+    ).resolves.toBeInstanceOf(Uint8Array);
+  });
+});

--- a/web/src/content/pdfs/ma/lic100-drivers-license-learners-permit-or-id-card/index.ts
+++ b/web/src/content/pdfs/ma/lic100-drivers-license-learners-permit-or-id-card/index.ts
@@ -1,0 +1,178 @@
+import { definePdf } from "#lib/pdfs/definePdf";
+import { formatDateMMDDYYYY } from "#lib/utils/formatDateMMDDYYYY";
+import { joinNames } from "#lib/utils/joinNames";
+import { joinParts } from "#lib/utils/joinParts";
+import pdf from "./lic100-drivers-license-learners-permit-or-id-card.pdf";
+import type { PdfFieldName } from "./schema";
+
+const stateIdType: Record<string, string> = {
+  realId: "REAL ID",
+  standardId: "Standard",
+};
+
+const documentToIssue: Record<string, string> = {
+  learnersPermit: "Learner's Permit",
+  driversLicense: "Driver's License",
+  massachusettsIdCard: "Massachusetts ID Card",
+};
+
+const licenseClass: Record<string, string> = {
+  passenger: "Passenger (Class D)",
+  motorcycle: "Motorcycle (Class M)",
+  both: "Both (Class D/M)",
+};
+
+const phoneType: Record<string, string> = {
+  cell: "Cell",
+  home: "Home",
+  work: "Work",
+};
+
+const gender: Record<string, string> = {
+  Female: "Female",
+  Male: "Male",
+  X: "Non-Binary",
+};
+
+const consentProviderType: Record<string, string> = {
+  parent: "Parent",
+  legalGuardian: "Legal guardian",
+  departmentOfChildrenAndFamilies: "Department of children and families",
+  boardingSchoolHeadmaster: "Boarding school headmaster",
+};
+
+const yesNo = (value: unknown) => {
+  if (value === true) return "Yes";
+  if (value === false) return "No";
+  return undefined;
+};
+
+// Ignore legacy or malformed unanswered radio values instead of sending them to libpdf.
+const radioValue = (value: unknown) =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+const formatHeight = (feet?: string, inches?: string) => {
+  if (!feet && !inches) return undefined;
+  return `${feet ?? ""}' ${inches ?? ""}"`.trim();
+};
+
+export default definePdf<PdfFieldName>({
+  id: "lic100-drivers-license-learners-permit-or-id-card",
+  title: "Driver's License, Learner's Permit, or ID Card Application",
+  code: "LIC100",
+  jurisdiction: "ma",
+  canonicalUrl:
+    "https://www.mass.gov/doc/license-and-id-application-0/download",
+  pdfPath: pdf,
+  drawFormControlValues: true,
+  resolver: (data) => ({
+    // A. Service Type
+    Type: stateIdType[radioValue(data.stateIdType) ?? ""],
+    "Document to Issue":
+      documentToIssue[radioValue(data.stateIdDocumentType) ?? ""],
+    "Class of Learner's Permit/License":
+      licenseClass[radioValue(data.driversLicenseClass) ?? ""],
+    "Service Type": "Change of Information",
+    Name: true,
+    Address: data.shouldChangeAddress === true,
+    DOB: data.shouldChangeDateOfBirth === true,
+    "Gender change": data.shouldChangeGenderMarker === true,
+    Height: data.shouldChangeHeight === true,
+    "Eye color": data.shouldChangeEyeColor === true,
+    // B. Applicant Information
+    "Last Name": data.newLastName,
+    "First Name": data.newFirstName,
+    "Middle Name": data.newMiddleName,
+    Suffix: data.nameSuffix,
+    "Current Massachusetts Learners Permit or Drivers License #":
+      data.currentMassachusettsCredentialNumber,
+    "Date of Birth": formatDateMMDDYYYY(data.dateOfBirth),
+    "Social Security Number": undefined,
+    "Foreign Passport": false,
+    Number: undefined,
+    "Consular ID": false,
+    "Country of Issuance": undefined,
+    "Name and number": joinParts(
+      joinNames(data.oldFirstName, data.oldMiddleName, data.oldLastName),
+      data.currentMassachusettsCredentialNumber,
+    ),
+    "Have you had a MA permit, license, ID, or registration?": true,
+    "Residential Address - Street": data.residenceStreetAddress,
+    "Residential Address - Apt #": data.residenceStreetAddress2,
+    "Residential Address - City": data.residenceCity,
+    "Residential Address - State": data.residenceState,
+    "Residential Address - Zip Code": data.residenceZipCode,
+    "Mailing Address - Street": data.isMailingAddressDifferentFromResidence
+      ? data.mailingStreetAddress
+      : undefined,
+    "same as above": data.isMailingAddressDifferentFromResidence === false,
+    "Mailing Address - Apt #": data.isMailingAddressDifferentFromResidence
+      ? data.mailingStreetAddress2
+      : undefined,
+    "Mailing Address - City": data.isMailingAddressDifferentFromResidence
+      ? data.mailingCity
+      : undefined,
+    "Mailing Address - State": data.isMailingAddressDifferentFromResidence
+      ? data.mailingState
+      : undefined,
+    "Mailing Address - Zip Code": data.isMailingAddressDifferentFromResidence
+      ? data.mailingZipCode
+      : undefined,
+    Email: data.email,
+    "Phone Type 1": phoneType[radioValue(data.phoneType) ?? ""],
+    Phone: data.phoneNumber,
+    "Emergency Contact Email": data.hasEmergencyContact
+      ? data.emergencyContactEmail
+      : undefined,
+    "Emergency Contact Name": data.hasEmergencyContact
+      ? data.emergencyContactName
+      : undefined,
+    "Phone Type 2": data.hasEmergencyContact
+      ? phoneType[radioValue(data.emergencyContactPhoneType) ?? ""]
+      : undefined,
+    "Emergency Contact Phone #": data.hasEmergencyContact
+      ? data.emergencyContactPhoneNumber
+      : undefined,
+    // C. Out of State Conversion
+    "Drivers License Learners Permit or ID Card": undefined,
+    "Document Type": undefined,
+    "Restrictions if applicable": undefined,
+    Country: undefined,
+    State: undefined,
+    "Issue Date": undefined,
+    "Expiration Date": undefined,
+    // D. Required Demographic Information
+    Gender: gender[radioValue(data.newGender) ?? ""],
+    "Eye Color": radioValue(data.eyeColor),
+    "Height (feet, inches)": formatHeight(data.heightFeet, data.heightInches),
+    "Organ and tissue donor": yesNo(data.isOrganDonor),
+    "Donate to organ and tissue donor fund": undefined,
+    "Are you an active duty member": data.isActiveDutyMilitary === true,
+    "If you are a veteran of the US Armed Forces do you":
+      data.shouldAddVeteranDesignation === true,
+    "Are you a veteran": data.isVeteran === true,
+    "What military branch": data.militaryBranch,
+    // E. CDL Downgrade does not apply to this transaction.
+
+    // F. Voter Registration
+    "Citizen of the Unites States of America": yesNo(data.isUSCitizen),
+    // G. Mandatory Questions
+    "License in another state, country, or jurisdiction": yesNo(
+      data.hasOtherJurisdictionCredential,
+    ),
+    "If yes where": data.otherCredentialJurisdiction,
+    "What credential class": data.otherCredentialClass,
+    "What credential #": data.otherCredentialNumber,
+    "List any current license/permit": data.currentOtherCredentials,
+    "Any impairment": yesNo(data.hasDrivingImpairment),
+    "Any medication": yesNo(data.takesDrivingMedication),
+    "License suspended": yesNo(data.hasSuspendedLicense),
+    // H. Parent/Guardian Consent
+    "Person giving consent":
+      consentProviderType[radioValue(data.consentProviderType) ?? ""],
+    "Parent/Guardian's Printed Name": data.guardianFullName,
+    "Parent/Guardian's Address": data.guardianAddress,
+    // I. Certification and Signature
+    Date: undefined,
+  }),
+});

--- a/web/src/lib/pdfs/__tests__/fillPdfDrawFormControlValues.test.ts
+++ b/web/src/lib/pdfs/__tests__/fillPdfDrawFormControlValues.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PDFDefinition } from "#constants/pdf";
+import { fillPdf } from "../fillPdf";
+
+// Ensure these are declared when Vitest hoists the module mocks below.
+const mocks = vi.hoisted(() => ({
+  drawText: vi.fn(),
+  fetchPdf: vi.fn(),
+  fill: vi.fn(),
+  load: vi.fn(),
+}));
+
+vi.mock("../fetchPdf", () => ({ fetchPdf: mocks.fetchPdf }));
+vi.mock("../loadPdfLib", () => ({
+  loadPdfLib: vi.fn().mockResolvedValue({
+    PDF: { load: mocks.load },
+    StandardFonts: { HelveticaBold: "HelveticaBold" },
+  }),
+}));
+
+describe("fillPdf drawn form controls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchPdf.mockResolvedValue(new ArrayBuffer(0));
+  });
+
+  it("draws only the selected widget for a string-valued checkbox group", async () => {
+    // A grouped checkbox uses one field name with a distinct on-value per widget.
+    const pageRef = { objectNumber: 1, generation: 0 };
+    const unselectedWidget = {
+      pageRef,
+      rect: [10, 10, 20, 20] as [number, number, number, number],
+      getOnValue: () => "First",
+    };
+    const selectedWidget = {
+      pageRef,
+      rect: [30, 10, 40, 20] as [number, number, number, number],
+      getOnValue: () => "Second",
+    };
+    const form = {
+      fill: mocks.fill,
+      getCheckbox: (name: string) =>
+        name === "choices"
+          ? {
+              getValue: () => "Second",
+              getWidgets: () => [unselectedWidget, selectedWidget],
+            }
+          : undefined,
+      getRadioGroup: () => undefined,
+    };
+
+    // Mock only the PDF document surface exercised by fillPdf.
+    mocks.load.mockResolvedValue({
+      setTitle: vi.fn(),
+      setAuthor: vi.fn(),
+      getForm: () => form,
+      getPages: () => [
+        {
+          ref: pageRef,
+          drawText: mocks.drawText,
+        },
+      ],
+      save: vi.fn().mockResolvedValue(new Uint8Array()),
+    });
+
+    const pdf: PDFDefinition = {
+      id: "lic100-drivers-license-learners-permit-or-id-card",
+      title: "Test Form",
+      canonicalUrl: "https://example.com",
+      pdfPath: "test.pdf",
+      drawFormControlValues: true,
+      resolver: () => ({
+        choices: "Second",
+        listbox: ["First", "Second"],
+      }),
+    };
+
+    await fillPdf({ pdf, userData: {} });
+
+    expect(mocks.fill).toHaveBeenCalledWith({
+      choices: "Second",
+      listbox: ["First", "Second"],
+    });
+    expect(mocks.drawText).toHaveBeenCalledOnce();
+    expect(mocks.drawText).toHaveBeenCalledWith(
+      "X",
+      expect.objectContaining({ x: 30.72, y: 10.18 }),
+    );
+  });
+
+  it("passes string arrays through as list-box values without drawing marks", async () => {
+    const form = {
+      fill: mocks.fill,
+      getCheckbox: () => undefined,
+      getRadioGroup: () => undefined,
+    };
+
+    // List boxes retain their native appearance and do not need an X mark.
+    mocks.load.mockResolvedValue({
+      setTitle: vi.fn(),
+      setAuthor: vi.fn(),
+      getForm: () => form,
+      getPages: () => [],
+      save: vi.fn().mockResolvedValue(new Uint8Array()),
+    });
+
+    const pdf: PDFDefinition = {
+      id: "lic100-drivers-license-learners-permit-or-id-card",
+      title: "Test Form",
+      canonicalUrl: "https://example.com",
+      pdfPath: "test.pdf",
+      drawFormControlValues: true,
+      resolver: () => ({ listbox: ["First", "Second"] }),
+    };
+
+    await fillPdf({ pdf, userData: {} });
+
+    expect(mocks.fill).toHaveBeenCalledWith({
+      listbox: ["First", "Second"],
+    });
+    expect(mocks.drawText).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/pdfs/fillPdf.ts
+++ b/web/src/lib/pdfs/fillPdf.ts
@@ -15,7 +15,7 @@ export async function fillPdf({
   userData: Partial<FormData>;
 }): Promise<Uint8Array> {
   try {
-    const { PDF } = await loadPdfLib();
+    const { PDF, StandardFonts } = await loadPdfLib();
 
     // Fetch the PDF with form fields
     const formPdfBytes = await fetchPdf(pdf.pdfPath);
@@ -39,6 +39,65 @@ export async function fillPdf({
         ),
       ),
     );
+
+    // Old method of drawing did not work for checkbox groups, so drawing
+    // permanent X marks into the page content using this method.
+    // This is opt-in, currently only used for LIC100.
+    if (pdf.drawFormControlValues && form) {
+      const pages = pdfDoc.getPages();
+
+      // Match each widget to its owning page before drawing in PDF coordinates.
+      const drawMark = (widget: {
+        pageRef: { objectNumber: number; generation: number } | null;
+        rect: [number, number, number, number];
+      }) => {
+        const pageRef = widget.pageRef;
+        const page = pages.find(
+          (candidate) =>
+            pageRef != null &&
+            candidate.ref.objectNumber === pageRef.objectNumber &&
+            candidate.ref.generation === pageRef.generation,
+        );
+        if (!page) return;
+
+        const [x1, y1, x2, y2] = widget.rect;
+        const size = Math.min(Math.abs(x2 - x1), Math.abs(y2 - y1)) * 0.9;
+        page.drawText("X", {
+          x: Math.min(x1, x2) + size * 0.08,
+          y: Math.min(y1, y2) + size * 0.02,
+          size,
+          font: StandardFonts.HelveticaBold,
+        });
+      };
+
+      for (const [name, value] of Object.entries(fields)) {
+        const checkbox = form.getCheckbox(name);
+        if (checkbox) {
+          // Read the filled state so checkbox groups mark only their selected widget.
+          const selectedValue = checkbox.getValue();
+          if (selectedValue !== "Off") {
+            for (const widget of checkbox.getWidgets()) {
+              if (widget.getOnValue() === selectedValue) drawMark(widget);
+            }
+          }
+          continue;
+        }
+
+        if (typeof value !== "string") continue;
+
+        const radio = form.getRadioGroup(name);
+        if (!radio) continue;
+
+        // Radio export values can differ from widget appearance-state names.
+        const options = radio.getOptions();
+        const exportIndex = radio.getExportValues().indexOf(value);
+        const selectedAppearance =
+          exportIndex >= 0 ? options[exportIndex] : value;
+        for (const widget of radio.getWidgets()) {
+          if (widget.getOnValue() === selectedAppearance) drawMark(widget);
+        }
+      }
+    }
 
     // Serialize the PDFDocument to bytes
     return await pdfDoc.save();


### PR DESCRIPTION
Fix for issue #701 
The cause turned out to be that the DOM was being altered when the mouse started the click, leading to chrome not registering a click.
This was found by a lot of tests that revealed the pointer was going down but no click was registering.
I diaganosed which part of the code was causing this by running the following in the devtools console:
const states = document.querySelectorAll(".state");

states.forEach(s => {
  const listeners = getEventListeners(s);
  ["mouseenter", "mousemove", "mouseleave"].forEach(type => {
    (listeners[type] || []).forEach(l =>
      s.removeEventListener(type, l.listener, l.useCapture)
    );
  });
});

This removed any listeners that could change the DOM after the mouse performed an action and then the clicking worked fine. After digging through web/src/components/SupportMap.astro I found the lines:
const node = hoveredState.node() as SVGPathElement;
if (node && node.parentNode) node.parentNode.appendChild(node);

which have the concequence of removing the element that is being clicked on and putting it to the end of the drawing list (presumably so that it can be seen above the rest of the states when enlarged).

I removed this code. Cannot see any visual bugs but please let me know if someone added this code for a reason that I cannot see. I warn that this fix has only been tested on Chrome, not Edge, but as they are both chromium and use the Blink rendering engine (unlike firefox and safari), I expect it to work.

Tom :)