### PR TITLE
Fix to make navigation to the state pages on supportmap work on chrome and edge

### DIFF
--- a/web/src/components/SupportMap.astro
+++ b/web/src/components/SupportMap.astro
@@ -286,9 +286,6 @@ function getFillForSupportLevel(supportLevel: string): string {
       const hoveredState = select(this as SVGPathElement);
       hoveredState.attr("data-hovered", "true");
 
-      const node = hoveredState.node() as SVGPathElement;
-      if (node && node.parentNode) node.parentNode.appendChild(node);
-
       tooltip
         .attr("data-visible", "true")
         .html(`<strong>${stateName}</strong><br/>${supportText}`);


### PR DESCRIPTION
Fix for issue #701 
---

The cause turned out to be that the DOM was being altered when the mouse started the click, leading to chrome not registering a click. This was found by a lot of tests that revealed the pointer was going down but no click was registering. I diaganosed which part of the code was causing this by running the following in the devtools console: const states = document.querySelectorAll(".state");

states.forEach(s => {
  const listeners = getEventListeners(s);
  ["mouseenter", "mousemove", "mouseleave"].forEach(type => {
    (listeners[type] || []).forEach(l =>
      s.removeEventListener(type, l.listener, l.useCapture)
    );
  });
});

---

This removed any listeners that could change the DOM after the mouse performed an action and then the clicking worked fine. After digging through web/src/components/SupportMap.astro I found the lines:
const node = hoveredState.node() as SVGPathElement; if (node && node.parentNode) node.parentNode.appendChild(node);

which have the concequence of removing the element that is being clicked on and putting it to the end of the drawing list (presumably so that it can be seen above the rest of the states when enlarged).

---

I removed this code. Cannot see any visual bugs but please let me know if someone added this code for a reason that I cannot see. I warn that this fix has only been tested on Chrome, not Edge, but as they are both chromium and use the Blink rendering engine (unlike firefox and safari), I expect it to work.

Tom :)