### PR TITLE
Fix support map click navigation while maintaining state outlines

### DIFF
--- a/web/src/components/SupportMap.astro
+++ b/web/src/components/SupportMap.astro
@@ -159,6 +159,18 @@ function getFillForSupportLevel(supportLevel: string): string {
           />
         ))
       }
+      <g class="state-outlines" aria-hidden="true">
+        {
+          stateFeatures.map((feature) => (
+            <path
+              class="state-outline"
+              d={path(feature)}
+              data-support={feature.properties.supportLevel}
+              data-name={feature.properties.name}
+            />
+          ))
+        }
+      </g>
     </svg>
     <figcaption class="legend">
       {
@@ -215,6 +227,7 @@ function getFillForSupportLevel(supportLevel: string): string {
   const container = select(".map-container");
   const svg = container.select("svg");
   const states = svg.selectAll("path.state");
+  const stateOutlines = svg.selectAll("path.state-outline");
   const legendItems = selectAll(".legend-item");
   const tooltip = container.select(".map-tooltip");
 
@@ -261,6 +274,7 @@ function getFillForSupportLevel(supportLevel: string): string {
 
   function clearHoverState() {
     states.attr("data-hovered", null);
+    stateOutlines.attr("data-hovered", null);
     tooltip.attr("data-visible", null);
   }
 
@@ -283,11 +297,16 @@ function getFillForSupportLevel(supportLevel: string): string {
         textMap[supportLevel as keyof typeof textMap] || "No Support Yet";
 
       states.attr("data-hovered", null);
+      stateOutlines.attr("data-hovered", null);
       const hoveredState = select(this as SVGPathElement);
       hoveredState.attr("data-hovered", "true");
-
-      const node = hoveredState.node() as SVGPathElement;
-      if (node && node.parentNode) node.parentNode.appendChild(node);
+      stateOutlines
+        .filter(function () {
+          return (
+            (this as SVGPathElement).getAttribute("data-name") === stateName
+          );
+        })
+        .attr("data-hovered", "true");
 
       tooltip
         .attr("data-visible", "true")
@@ -298,7 +317,17 @@ function getFillForSupportLevel(supportLevel: string): string {
       positionTooltip(event);
     })
     .on("mouseleave", function () {
+      const stateName =
+        (this as SVGPathElement).getAttribute("data-name") || "";
+
       select(this as SVGPathElement).attr("data-hovered", null);
+      stateOutlines
+        .filter(function () {
+          return (
+            (this as SVGPathElement).getAttribute("data-name") === stateName
+          );
+        })
+        .attr("data-hovered", null);
       tooltip.attr("data-visible", null);
     });
 
@@ -323,6 +352,15 @@ function getFillForSupportLevel(supportLevel: string): string {
         .attr("data-dimmed", null)
         .attr("data-hovered", "true");
 
+      stateOutlines
+        .filter(function () {
+          return (
+            (this as SVGPathElement).getAttribute("data-support") ===
+            hoveredType
+          );
+        })
+        .attr("data-hovered", "true");
+
       legendItems
         .filter(function () {
           return (
@@ -333,6 +371,7 @@ function getFillForSupportLevel(supportLevel: string): string {
     })
     .on("mouseout", function () {
       states.attr("data-dimmed", null).attr("data-hovered", null);
+      stateOutlines.attr("data-hovered", null);
       legendItems.attr("data-dimmed", null);
     });
 </script>
@@ -386,13 +425,22 @@ function getFillForSupportLevel(supportLevel: string): string {
     vector-effect: non-scaling-stroke;
     cursor: pointer;
 
-    &[data-hovered="true"] {
-      stroke: var(--text-color);
-      stroke-width: 2;
-    }
-
     &[data-dimmed="true"] {
       opacity: 0.2;
+    }
+  }
+
+  .state-outline {
+    fill: none;
+    stroke: transparent;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2;
+    vector-effect: non-scaling-stroke;
+    pointer-events: none;
+
+    &[data-hovered="true"] {
+      stroke: var(--text-color);
     }
   }
 

--- a/web/src/components/SupportMap.astro
+++ b/web/src/components/SupportMap.astro
@@ -301,11 +301,7 @@ function getFillForSupportLevel(supportLevel: string): string {
       const hoveredState = select(this as SVGPathElement);
       hoveredState.attr("data-hovered", "true");
       stateOutlines
-        .filter(function () {
-          return (
-            (this as SVGPathElement).getAttribute("data-name") === stateName
-          );
-        })
+        .filter(`[data-name="${stateName}"]`)
         .attr("data-hovered", "true");
 
       tooltip

--- a/web/src/components/SupportMap.astro
+++ b/web/src/components/SupportMap.astro
@@ -335,30 +335,16 @@ function getFillForSupportLevel(supportLevel: string): string {
       states.attr("data-dimmed", "true");
 
       states
-        .filter(function () {
-          return (
-            (this as SVGPathElement).getAttribute("data-support") ===
-            hoveredType
-          );
-        })
+        .filter(`[data-support="${hoveredType}"]`)
         .attr("data-dimmed", null)
         .attr("data-hovered", "true");
 
       stateOutlines
-        .filter(function () {
-          return (
-            (this as SVGPathElement).getAttribute("data-support") ===
-            hoveredType
-          );
-        })
+        .filter(`[data-support="${hoveredType}"]`)
         .attr("data-hovered", "true");
 
       legendItems
-        .filter(function () {
-          return (
-            (this as HTMLElement).getAttribute("data-type") !== hoveredType
-          );
-        })
+        .filter(`:not([data-type="${hoveredType}"])`)
         .attr("data-dimmed", "true");
     })
     .on("mouseout", function () {

--- a/web/src/components/SupportMap.astro
+++ b/web/src/components/SupportMap.astro
@@ -318,11 +318,7 @@ function getFillForSupportLevel(supportLevel: string): string {
 
       select(this as SVGPathElement).attr("data-hovered", null);
       stateOutlines
-        .filter(function () {
-          return (
-            (this as SVGPathElement).getAttribute("data-name") === stateName
-          );
-        })
+        .filter(`[data-name="${stateName}"]`)
         .attr("data-hovered", null);
       tooltip.attr("data-visible", null);
     });


### PR DESCRIPTION
Fix for issue #701 
---

The cause turned out to be that the DOM was being altered when the mouse started the click, leading to chrome not registering a click. I diaganosed which part of the code was causing this by running the following in the devtools console: const states = document.querySelectorAll(".state");

states.forEach(s => {
  const listeners = getEventListeners(s);
  ["mouseenter", "mousemove", "mouseleave"].forEach(type => {
    (listeners[type] || []).forEach(l =>
      s.removeEventListener(type, l.listener, l.useCapture)
    );
  });
});

---

This removed any listeners that could change the DOM after the mouse performed an action and then the clicking worked fine. After digging through web/src/components/SupportMap.astro I found the lines:
const node = hoveredState.node() as SVGPathElement; if (node && node.parentNode) node.parentNode.appendChild(node);

which have the concequence of removing the element that is being clicked on and putting it to the end of the drawing list (presumably so that it can be seen above the rest of the states when enlarged).

---

I removed this code and added a new outline layer above all states, triggered by existing functions like mouseenter and mouseleave.
I warn that this fix has only been tested on Chrome, not Edge, but as they are both chromium and use the Blink rendering engine (unlike firefox and safari), I expect it to work.

Tom :)