### PR TITLE
FIX: Images fail to load in dev environment following cloudflare version upgrade

### DIFF
--- a/web/astro.config.ts
+++ b/web/astro.config.ts
@@ -3,11 +3,7 @@ import { satteri } from "@astrojs/markdown-satteri";
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
-import {
-  defineConfig,
-  fontProviders,
-  passthroughImageService,
-} from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import pagefind from "astro-pagefind";
 import browserslist from "browserslist";
 import { browserslistToTargets } from "lightningcss";
@@ -19,9 +15,6 @@ export default defineConfig({
   adapter: cloudflare({
     imageService: "compile",
   }),
-  image: {
-    service: passthroughImageService(),
-  },
   markdown: {
     processor: satteri({
       mdastPlugins: [satteriModifiedTime],


### PR DESCRIPTION
Fix for issue #723 

After cloudflare was upgraded, the following code began to conflict in astro.config.ts lines 19-24:
> adapter: cloudflare({
>   imageService: "compile",
> }),
> image: {
>   service: passthroughImageService(),
> },

This caused images to fail to load in dev env with 400 error.

---

If we want to use passthrough, we can change imageService: "compile" to imageService: "passthrough". However, due to recent image optomisation commits, I decided to delete:
> image: {
>   service: passthroughImageService(),
> },

and leave imageService: "compile".

---

Tested by adding and removing this code and watching the site with pnpm dev. Images showed only when service: passthroughImageService was deleted.