### PR TITLE
Omit paths and query params when formatting clean URLs for display

### DIFF
--- a/web/src/lib/utils/__tests__/formatCleanUrl.test.ts
+++ b/web/src/lib/utils/__tests__/formatCleanUrl.test.ts
@@ -15,17 +15,15 @@ describe("formatCleanUrl", () => {
     expect(formatCleanUrl("https://namesake.fyi/")).toBe("namesake.fyi");
   });
 
-  it("removes only a single trailing slash at the end", () => {
-    expect(formatCleanUrl("https://example.com/path/")).toBe(
-      "example.com/path",
-    );
-  });
-
   it("leaves host-only strings unchanged", () => {
     expect(formatCleanUrl("example.com")).toBe("example.com");
   });
 
-  it("returns empty string for empty input", () => {
-    expect(formatCleanUrl("")).toBe("");
+  it("omits the path, query, and fragment", () => {
+    expect(
+      formatCleanUrl(
+        "https://law.uic.edu/experiential-education/clinics/pro-bono/projects/?source=directory#services",
+      ),
+    ).toBe("law.uic.edu");
   });
 });

--- a/web/src/lib/utils/formatCleanUrl.ts
+++ b/web/src/lib/utils/formatCleanUrl.ts
@@ -1,10 +1,12 @@
 /**
- * Given a URL, return the URL without protocol, "www", or trailing slash.
+ * Given a URL or hostname, return its hostname without "www".
  *
  * @example
  * formatCleanUrl("https://www.masstpc.org/")
  * // "masstpc.org"
  */
 export function formatCleanUrl(url: string): string {
-  return url.replace(/^https?:\/\/(www\.)?/, "").replace(/\/$/, "");
+  const absoluteUrl = url.includes("://") ? url : `https://${url}`;
+
+  return new URL(absoluteUrl).hostname.replace(/^www\./, "");
 }

--- a/web/src/lib/utils/formatCleanUrl.ts
+++ b/web/src/lib/utils/formatCleanUrl.ts
@@ -6,6 +6,7 @@
  * // "masstpc.org"
  */
 export function formatCleanUrl(url: string): string {
+  // Ensure handling of links that are already hostnames without typeerror
   const absoluteUrl = url.includes("://") ? url : `https://${url}`;
 
   return new URL(absoluteUrl).hostname.replace(/^www\./, "");


### PR DESCRIPTION
A feature for PR #729, the implementation of issue #720 

---

This method allows org entries in the directory to show only the org domain while directing to a specific page on the site when clicked.

This will not affect any of the current links yet but testing can be done with:
pnpm --dir web test:once src/lib/utils/__tests__/formatCleanUrl.test.ts

Almost finished adding all the org entries to the directory for Illinois, Kentucky, North Carolina, which use this method.

---

**Before**
<img width="1602" height="1200" alt="Screenshot 2026-07-27 073409" src="https://github.com/user-attachments/assets/3d6b04c0-9f87-470d-89ad-184c12ce40da" />


**After (still directs to same link when clicked)**
<img width="1500" height="1176" alt="Screenshot 2026-07-27 073620" src="https://github.com/user-attachments/assets/de6b77dc-efcd-4a95-a892-9e47f0ed0bed" />
