### PR TITLE
Add support for extensions in phone numbers

### DIFF
--- a/docs/src/content/docs/guides/directory-updates.mdx
+++ b/docs/src/content/docs/guides/directory-updates.mdx
@@ -28,7 +28,7 @@ Each entry in the directory needs the following info:
 | URL | A link to the organization's website. If the organization/website is large, link directly to the most relevant page for name change information. |
 | Services | One or more of the following tags: `financial aid`, `form filling help`, `legal support`, `name change clinics`, and `notary` |
 | Email | A contact email address. _Optional._ |
-| Phone | A contact phone number. Format should match `000-000-0000`. _Optional._ |
+| Phone | A contact phone number. Format should match `000-000-0000`. An extension can be added with a semicolon followed by the digits, e.g. `000-000-0000;1234`. _Optional._ |
 | Logo | The organization's logo. _Optional._ |
 
 Usually, this information is available directly through an organization's website. If any details are uncertain, such as the services offered, email or call the organization to confirm.

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -57,7 +57,7 @@ const directory = defineCollection({
       email: z.email().optional(),
       phone: z
         .string()
-        .regex(/^\d{3}-\d{3}-\d{4}$/)
+        .regex(/^\d{3}-\d{3}-\d{4}(;\d{1,4})?$/)
         .optional(),
       logo: image().optional(),
     }),

--- a/web/src/content/directory/uic/index.yml
+++ b/web/src/content/directory/uic/index.yml
@@ -9,5 +9,5 @@ services:
   - financialAid
   - legal
 email: law-probono@uic.edu
-phone: 312-427-2737
+phone: 312-427-2737;477
 logo: ./logo.png

--- a/web/src/lib/utils/__tests__/formatPhone.test.ts
+++ b/web/src/lib/utils/__tests__/formatPhone.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { formatPhone } from "../formatPhone";
+
+describe("formatPhone", () => {
+  it("returns the number unchanged when there is no extension", () => {
+    expect(formatPhone("555-555-5555")).toBe("555-555-5555");
+  });
+
+  it("appends the extension when present", () => {
+    expect(formatPhone("555-555-5555;1234")).toBe("555-555-5555 ext. 1234");
+  });
+
+  it("handles extensions shorter than 4 digits", () => {
+    expect(formatPhone("555-555-5555;1")).toBe("555-555-5555 ext. 1");
+  });
+});

--- a/web/src/lib/utils/formatPhone.ts
+++ b/web/src/lib/utils/formatPhone.ts
@@ -1,0 +1,16 @@
+/**
+ * Given a phone number with an optional extension, return a human readable string.
+ *
+ * @example
+ * formatPhone("555-555-5555")
+ * // "555-555-5555"
+ *
+ * @example
+ * formatPhone("555-555-5555;1234")
+ * // "555-555-5555 ext. 1234"
+ */
+export function formatPhone(phone: string): string {
+  const [number, extension] = phone.split(";");
+
+  return extension ? `${number} ext. ${extension}` : number;
+}

--- a/web/src/pages/directory/index.astro
+++ b/web/src/pages/directory/index.astro
@@ -15,6 +15,7 @@ import PageHeader from "#components/PageHeader.astro";
 import { SERVICE_LABELS, SERVICES, type Service } from "#constants/services";
 import BaseLayout from "#layouts/BaseLayout.astro";
 import { formatCleanUrl } from "#lib/utils/formatCleanUrl";
+import { formatPhone } from "#lib/utils/formatPhone";
 
 const stateParam = Astro.url.searchParams.get("state");
 const serviceParam = Astro.url.searchParams.get("service");
@@ -177,7 +178,9 @@ const description =
                   <li>
                     <RiPhoneLine size={18} />
                     <div class="contact-label">
-                      <a href={`tel:${contact.phone}`}>{contact.phone}</a>
+                      <a href={`tel:${contact.phone}`}>
+                        {formatPhone(contact.phone)}
+                      </a>
                     </div>
                   </li>
                 )}


### PR DESCRIPTION
- Update the content collection regex for `phone` to accept an optional semicolon and up to 4 digits for an extension
- Add a new `formatPhone` util to return the phone number with the word "ext." if an extension exists
- Update the directory display
- Update the UIC Law entry to include their phone extension
- Closes #731 

<img width="632" height="184" alt="CleanShot 2026-07-28 at 11 16 19@2x" src="https://github.com/user-attachments/assets/e15c94a4-4fca-4cc8-b423-d59c5e8962d2" />