### PR TITLE
Set up Codespaces config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,10 @@
     "5432": {
       "label": "Docs",
       "onAutoForward": "openPreview"
+    },
+    "3456": {
+      "label": "PDF Manager",
+      "onAutoForward": "openPreview"
     }
   },
   "updateContentCommand": "pnpm install",
@@ -27,6 +31,4 @@
       ]
     }
   }
-  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-  // "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+  "name": "Namesake",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:4-24-trixie",
+  "features": {
+    "ghcr.io/devcontainers-extra/features/pnpm:2": {}
+  },
+  "forwardPorts": [4321, 5432],
+  "portsAttributes": {
+    "4321": {
+      "label": "Website",
+      "onAutoForward": "openPreview"
+    },
+    "5432": {
+      "label": "Docs",
+      "onAutoForward": "openPreview"
+    }
+  },
+  "updateContentCommand": "pnpm install",
+  "postAttachCommand": "pnpm dev",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "astro-build.astro-vscode",
+        "deque-systems.vscode-axe-linter",
+        "biomejs.biome",
+        "ms-playwright.playwright"
+      ]
+    }
+  }
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,29 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for more information:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-# https://containers.dev/guide/dependabot
-
 version: 2
-updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+updates: 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      patch-minor:
+        update-types: ["patch", "minor"]
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    groups:
-      actions-deps:
-        patterns:
-          - "*"
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      patch-minor:
-        update-types: ["patch", "minor"]
-    cooldown:
-      default-days: 7
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repository contains the source code for [namesake.fyi](https://namesake.fyi
 
 We 💖 our contributors! Namesake is built by, and for, the trans community, and we welcome contributors of all genders and skill levels.
 
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/namesakefyi/namesake?quickstart=1)
+
 - Read the [contributior manual](https://docs.namesake.fyi) to learn how to set up your local environment, create new forms, and more.
 - Keep Namesake safe for everyone by reviewing our [code of conduct](https://github.com/namesakefyi/namesake?tab=coc-ov-file).
 - [Donate](https://namesake.fyi/donate) to support our work.


### PR DESCRIPTION
Add a `devcontainer` config for Codespaces:
- Automatically install recommended extensions (Astro, Biome, etc.)
- Automatically install packages on run
- Automatically run `pnpm dev` on boot (opens preview window)

Add "Open in Codespaces" badge to main README

Update `devcontainers` with Dependabot.

You can test by opening a new Codespace from the GitHub U (from [this branch](https://github.com/namesakefyi/namesake/tree/codespaces)):

<img width="917" height="976" alt="CleanShot 2026-07-31 at 18 49 48@2x" src="https://github.com/user-attachments/assets/1717e660-1924-4358-a55f-952e11dc7f56" />

This should open an in-browser version of VSCode, install dependencies, and eventually, open a preview window for the Namesake website.

This is the first step in a process of making it easier for new contributors to get set up working with Namesake. Will follow-up with more detailed documentation.